### PR TITLE
Fix ANU declaration after use for ifort compatibility

### DIFF
--- a/src/Core/fjx_sub_mod.f90
+++ b/src/Core/fjx_sub_mod.f90
@@ -158,10 +158,10 @@
       real*8,  intent(in), dimension(L1U  )  :: IWP   ! cloud-j input
       real*8,  intent(in), dimension(L1U  )  :: REFFL ! cloud-j input
       real*8,  intent(in), dimension(L1U  )  :: REFFI ! cloud-j input
+      integer, intent(in)                    :: ANU   ! cloud-j input
       real*8,  intent(in), dimension(L1U,ANU):: AERSP ! cloud-j input
       integer, intent(in), dimension(L1U,ANU):: NDXAER! cloud-j input
       integer, intent(in)                    :: L1U   ! cloud-j input
-      integer, intent(in)                    :: ANU   ! cloud-j input
       integer, intent(in)                    :: NJXU  ! cloud-j input
 ! reports out the JX J-values, upper level program converts to CTM chemistry J's
       real*8,intent(out), dimension(L1U-1,NJXU):: VALJXX ! cloud-j output


### PR DESCRIPTION
When building Cloud-J in GEOS-Chem with `ifort` I run into the following compile error:

```
src/Cloud-J/src/Core/fjx_sub_mod.f90(164): error #6415: This name cannot be assigned this data type because it conflicts with prior uses of the name.   [ANU]
      integer, intent(in)                    :: ANU   ! cloud-j input
```

This is because the declarations of `AERSP` and `NDXAER` dimensions use `ANU`, but `ANU` is declared two lines later. It appears that `ifort` enforces the Fortran standard of declaration orders where `ANU` must come before all usage, so I moved the declaration so the code would build correctly.

Thanks!
Haipeng