### PR TITLE
Pass root thread logical to init subroutines

### DIFF
--- a/src/Core/cldj_init_mod.f90
+++ b/src/Core/cldj_init_mod.f90
@@ -28,10 +28,11 @@
       CONTAINS
 
 !-----------------------------------------------------------------------
-      subroutine INIT_CLDJ (DATADIR,NLEVELS,TITLEJXX,NJXU,NJXX)
+      subroutine INIT_CLDJ (AMIROOT,DATADIR,NLEVELS,TITLEJXX,NJXU,NJXX)
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in)          :: AMIROOT
       character(LEN=*), intent(in) :: DATADIR
       integer, intent(in)          :: NLEVELS
       integer, intent(in)          :: NJXU
@@ -41,7 +42,7 @@
       character*120  TIT_SPEC
       integer  JXUNIT,I, J, K, KR, RANSEED, NUN
 
-      write(6,*) ' Solar/Cloud-J  ver-7.7 initialization'
+      if (AMIROOT) write(6,*) ' Solar/Cloud-J  ver-7.7 initialization'
 
       ! Set cldj_cmn_mod variables based on input numbers of levels
       L_    = NLEVELS
@@ -57,7 +58,7 @@
       open (NUN,FILE=TRIM(DATADIR)//'CJ77_inp.dat',status='old', &
             form='formatted')
       read (NUN,'(a120)',err=4) TIT_SPEC
-         write(6,'(a)') trim(TIT_SPEC)
+         if (AMIROOT) write(6,'(a)') trim(TIT_SPEC)
       read (NUN,'(e10.3)',err=4) RAD
       read (NUN,'(e10.3)',err=4) ZZHT
       read (NUN,'(e10.3)',err=4) ATAU
@@ -69,7 +70,7 @@
       read (NUN,'(i10  )',err=4) NRANDO
       read (NUN,'(i10  )',err=4) ATM0
       read (NUN,'(i10  )',err=4) CLDFLAG
-         write(6,'(a,3i5)') ' finish params LNRG ATM0 CLDFLAG',LNRG,ATM0,CLDFLAG
+         if (AMIROOT) write(6,'(a,3i5)') ' finish params LNRG ATM0 CLDFLAG',LNRG,ATM0,CLDFLAG
       close (NUN)
 
       ! Uncomment below to set cloud scheme to clear sky for testing
@@ -110,14 +111,14 @@
 !sJ!         LCLIRAD =.false.
 !sJ!         LGGLLNL =.true.
 !sJ!      endif
-      write(6,'(a,3l2)')'LRRTMG/LCLIRAD/LGGLLNL=', LRRTMG, LCLIRAD, LGGLLNL
+      if (AMIROOT) write(6,'(a,3l2)')'LRRTMG/LCLIRAD/LGGLLNL=', LRRTMG, LCLIRAD, LGGLLNL
 
 !  inital RRTMG setup is done in subrotine CHEM_IN of p-input.f
 !  note that (if(LRRTMG) call RRTMG_SW_INI(cpdair)) is in CHEM_in of p-input.f
 !  lock indexing of RRTMg superbins (1:W_+W_r) onto std bins fluxes (1:S_)
-      write(6,'(a,i3,a,i3,a,i3,a,i3)') 'W_rrtmg= ',W_rrtmg,'  S_=',S_, &
+      if (AMIROOT) write(6,'(a,i3,a,i3,a,i3,a,i3)') 'W_rrtmg= ',W_rrtmg,'  S_=',S_, &
             '  W_r=',W_r,'  W_+ W_r= ',W_+W_r
-      write(6,'(a,f8.4,a,f8.4,a,i2)') 'ATAU0=',ATAU0,'  ATAU=',ATAU, &
+      if (AMIROOT) write(6,'(a,f8.4,a,f8.4,a,i2)') 'ATAU0=',ATAU0,'  ATAU=',ATAU, &
             '   option(ATM0)= ', ATM0
 
 ! with Cloud-J v7.6, NO wavelength truncation for trop only, internal fixes
@@ -134,7 +135,7 @@
       ANGLES(5) = 0.e0 ! assgin U0 in photol_mod.f90
 
 ! Read in Fast/Solar-J X-sections (spectral data)
-      call RD_XXX(JXUNIT,TRIM(DATADIR)//'FJX_spec.dat')
+      call RD_XXX(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_spec.dat')
 
       if (.not.(LRRTMG .or. LCLIRAD .or. LGGLLNL)) then
          do I = W_,  S_
@@ -148,7 +149,7 @@
          do J = 1,NSJSUB(K)
             KR = KR+1
             KDOKR(KR) = K
-            write(6,'(A,2I5)')'KR/KDOKR(KR)',KR, KDOKR(KR)
+            if (AMIROOT) write(6,'(A,2I5)')'KR/KDOKR(KR)',KR, KDOKR(KR)
          enddo
       enddo
       if (KR .ne. W_+W_r) CALL EXITC('>>>error w/ RRTM sub bins: KDOKR')
@@ -162,28 +163,28 @@
       enddo
 
 ! Read in cloud scattering data
-      call RD_CLD(JXUNIT,TRIM(DATADIR)//'FJX_scat-cld.dat')
+      call RD_CLD(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-cld.dat')
 
 ! Read in strat sulf aerosols scattering data
-      call RD_SSA(JXUNIT,TRIM(DATADIR)//'FJX_scat-ssa.dat')
+      call RD_SSA(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-ssa.dat')
 
 ! Read in aerosols scattering data
-      call RD_MIE(JXUNIT,TRIM(DATADIR)//'FJX_scat-aer.dat')
+      call RD_MIE(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-aer.dat')
 
 ! Read in UMich aerosol scattering data
-      call RD_UM (JXUNIT,TRIM(DATADIR)//'FJX_scat-UMa.dat')
+      call RD_UM (AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-UMa.dat')
 
 ! Read in GEOMIP aerosol scattering data
-      call RD_GEO (JXUNIT,TRIM(DATADIR)//'FJX_scat-geo.dat')
+      call RD_GEO (AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-geo.dat')
 
 ! Read in T & O3 climatology used to fill e.g. upper layers or if O3 not calc.
-      call RD_PROF(JXUNIT,TRIM(DATADIR)//'atmos_std.dat')
+      call RD_PROF(AMIROOT,JXUNIT,TRIM(DATADIR)//'atmos_std.dat')
 
 ! Read in H2O and CH4 profiles for Solar-J
-      call RD_TRPROF(JXUNIT,TRIM(DATADIR)//'atmos_h2och4.dat')
+      call RD_TRPROF(AMIROOT,JXUNIT,TRIM(DATADIR)//'atmos_h2och4.dat')
 
 ! Read in zonal mean Strat-Sulf-Aerosol monthly data
-      call RD_SSAPROF(JXUNIT,TRIM(DATADIR)//'atmos_geomip.dat')
+      call RD_SSAPROF(AMIROOT,JXUNIT,TRIM(DATADIR)//'atmos_geomip.dat')
 
       NJXX = NJX
       do J = 1,NJXX
@@ -192,7 +193,7 @@
 
 ! Read in photolysis rates used in chemistry code and mapping onto FJX J's
 !---CTM call:  read in J-values names and link to fast-JX names
-      call RD_JS_JX(JXUNIT,TRIM(DATADIR)//'FJX_j2j.dat', TITLEJXX,NJXX)
+      call RD_JS_JX(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_j2j.dat', TITLEJXX,NJXX)
 
 !---for full ASAD:
 !     call RD_JS(JXUNIT,TRIM(DATADIR)//'ratj.d', TITLEJXX,NJXX,TSPECI,JPSPEC  &
@@ -207,13 +208,13 @@
         call EXITC(' CLDJ_INIT: error in read')
     1 continue
 
-      write(6,*) ' end of Solar/Cloud-J initialization'
+      if (AMIROOT) write(6,*) ' end of Solar/Cloud-J initialization'
 
       END SUBROUTINE INIT_CLDJ
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_XXX(NUN,NAMFIL)
+      subroutine RD_XXX(AMIROOT,NUN,NAMFIL)
 !-----------------------------------------------------------------------
 !  Read in wavelength bins, solar fluxes, Rayleigh, T-dep X-sections.
 !
@@ -242,6 +243,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
       integer  I, J, JJ, K, IW, NQRD, LQ, NWWW, NSSS
@@ -265,8 +267,8 @@
       read (NUN,*,err=4)
       read (NUN,'(i5,5x,i5)',err=4) NWWW, NSSS
 
-      write(6,'(a)') adjustl(trim(TIT_SPEC))
-      write(6,'(i5,A20,i5,A20)')  NWWW, ' photo-chem wl bins ', &
+      if (AMIROOT) write(6,'(a)') adjustl(trim(TIT_SPEC))
+      if (AMIROOT) write(6,'(i5,A20,i5,A20)')  NWWW, ' photo-chem wl bins ', &
             NSSS, ' solar heating bins '
 
       if (NWWW.gt.WX_ .or. NSSS.gt.SX_) then
@@ -281,43 +283,43 @@
 !----w-params:  1=w-eff  2=w-bins, 3=solar(photons), 4=solar(W/m2), 5=Y-PAR,
 ! 6=Rayleigh, 7=SJ sub-bins
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
       read (NUN,'(5x,6e10.3)',err=4)    (WL(IW),IW=1,NSSS)
 
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
       read (NUN,'(5x,6e10.3)',err=4)    (WBIN(IW),IW=1,NSSS)
 
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
       read (NUN,'(5x,6e10.3)',err=4)    (FL(IW),IW=1,NSSS)
 
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
       read (NUN,'(5x,6e10.3)',err=4)    (FW(IW),IW=1,NSSS)
          FWSUM=0.d0
          do IW=1, NSSS
             FWSUM= FWSUM + FW(IW)
          enddo
-         write(6,*) 'total Solar flux=', FWSUM
+         if (AMIROOT) write(6,*) 'total Solar flux=', FWSUM
 
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
       read (NUN,'(5x,6e10.3)',err=4)    (FPAR(IW),IW=1,NSSS)
 
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                         ' notes: ', adjustl(trim(TIT_J1N))
       read (NUN,'(5x,6e10.3)',err=4)    (QRAYL(IW),IW=1,NSSS)
 
 !7 SJ-sub-bins
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
       do I = 1,NSSS
         SJSUB(I,1)    = 1.0d0
@@ -327,7 +329,7 @@
 !SJ! this is different in SJ, allows for SJSBU(:,1:16)  ? RRTM
          do I= NWWW, NSSS  ! fraction of solar radiation for each sub-bin
             read  (NUN,'(5x,5f10.5)',err=4) (SJSUB(I,IW),IW=1,15)
-               write(6,'(5x,5f10.6)') (SJSUB(I,IW),IW=1,15)
+               if (AMIROOT) write(6,'(5x,5f10.6)') (SJSUB(I,IW),IW=1,15)
          enddo
       endif
 
@@ -347,7 +349,7 @@
          TITLEJX(1) = TIT_J1S
          TITLEJL(1) = TIT_J1L
          LQQ(1) = 3
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
 
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
@@ -364,7 +366,7 @@
         TITLEJX(2) = TIT_J1S
         TITLEJL(2) = TIT_J1L
         LQQ(2) = 3
-        write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+        if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                           ' notes: ',adjustl(trim(TIT_J1N))
 
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
@@ -381,7 +383,7 @@
         TITLEJX(3) = TIT_J1S
         TITLEJL(3) = TIT_J1L
         LQQ(3) = 3
-        write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+        if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                           ' notes: ',adjustl(trim(TIT_J1N))
 
 !---Read remaining species:  X-sections at 1-2-3 T_s
@@ -390,7 +392,7 @@
 !-- read new Xsection block
     3 continue
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-        write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+        if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                           ' notes: ',adjustl(trim(TIT_J1N))
         if (TIT_J1S .eq. 'endofJ') goto 1
 !---try to add a new Xsect
@@ -405,7 +407,7 @@
         LQQ(JJ) = LQ
 !try to read a 2nd Temperature or Pressure
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-        write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+        if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                           ' notes: ',adjustl(trim(TIT_J1N))
         if (TIT_J1S .eq. 'endofJ') goto 1
       if (TIT_J1S .eq. TITLEJX(JJ)) then
@@ -415,7 +417,7 @@
         LQQ(JJ) = LQ
 !try to read a 3rd Temperature or Pressure
       read (NUN,'(a6,1x,a16,1x,a120)',err=4) TIT_J1S,TIT_J1L,TIT_J1N
-         write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
+         if (AMIROOT) write(6,'(1x,a6,1x,a16,a8,a)') trim(TIT_J1S),trim(TIT_J1L), &
                                            ' notes: ',adjustl(trim(TIT_J1N))
          if (TIT_J1S .eq. 'endofJ') goto 1
        if (TIT_J1S .eq. TITLEJX(JJ)) then
@@ -439,7 +441,7 @@
 !---    possibly also for WACCM >200nm-only version.
 !---TROP-ONLY (W_ = 12 or 8) then drop the strat Xsects (labeled 'x')
       if (NWBIN .eq. 12 .or. NWBIN .eq. 8) then
-         write(6,'(a)')  &
+         if (AMIROOT) write(6,'(a)')  &
               ' >>>TROP-ONLY reduced wavelengths, drop strat X-sects'
          JJ = 3
          do J = 4,NJX
@@ -463,7 +465,7 @@
       endif
 
       do J = 1,NJX
-         write(6,'(a8,i5,2x,a6,2x,a16,2x,a1,i3,2x,3f6.1)') &
+         if (AMIROOT) write(6,'(a8,i5,2x,a6,2x,a16,2x,a1,i3,2x,3f6.1)') &
            'X-sects', J,trim(TITLEJX(J)),trim(TITLEJL(J)), &
            SQQ(J),LQQ(J),(TQQ(I,J),I=1,LQQ(J))
       enddo
@@ -503,7 +505,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_CLD(NUN,NAMFIL)
+      subroutine RD_CLD(AMIROOT,NUN,NAMFIL)
 !-----------------------------------------------------------------------
 !-------aerosols/cloud scattering data set for fast-JX ver 7.5
 !-----------------------------------------------------------------------
@@ -519,6 +521,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
 
@@ -529,10 +532,10 @@
       open (NUN,FILE=NAMFIL,status='old',form='formatted',err=4)
 
         read (NUN,'(a80)',err=4) TITLE0
-          write(6,'(a)') trim(TITLE0)                                
+          if (AMIROOT) write(6,'(a)') trim(TITLE0)                                
         read (NUN,'(i4)')  NCC
         read (NUN,'(i4)')  MCC
-          write(6,'(3i6,a)') NCC,MCC,SX_,' types of clouds & #Reff'
+          if (AMIROOT) write(6,'(3i6,a)') NCC,MCC,SX_,' types of clouds & #Reff'
         read (NUN,*)
         read (NUN,*)
         read (NUN,*)
@@ -541,7 +544,7 @@
 
         do K = 1, NCC
            read (NUN,'(a12,f8.5)',err=4) TITLCC(K),DCC(K)
-           write(6,'(a,i4,1x,a12,f8.5)') 'Cloud#',K,trim(TITLCC(K)),DCC(K)
+           if (AMIROOT) write(6,'(a,i4,1x,a12,f8.5)') 'Cloud#',K,trim(TITLCC(K)),DCC(K)
            do J = 12, SX_
               do I = 1,MCC
                  read (NUN, &
@@ -579,13 +582,13 @@
     2 continue
         close(NUN)
 
-         write(6,'(a,2f9.5,i5)') ' ATAU/ATAU0',ATAU,ATAU0
+         if (AMIROOT) write(6,'(a,2f9.5,i5)') ' ATAU/ATAU0',ATAU,ATAU0
 
       END SUBROUTINE RD_CLD
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_SSA(NUN,NAMFIL)
+      subroutine RD_SSA(AMIROOT,NUN,NAMFIL)
 !-----------------------------------------------------------------------
 !-------aerosols/cloud scattering data set for fast-JX ver 7.4
 !-----------------------------------------------------------------------
@@ -603,6 +606,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
 
@@ -612,16 +616,16 @@
 
       open (NUN,FILE=NAMFIL,status='old',form='formatted',err=4)
       read (NUN,'(a120)',err=4) TITLE0
-      write(6,'(a)') adjustl(trim(TITLE0))
+      if (AMIROOT) write(6,'(a)') adjustl(trim(TITLE0))
       read (NUN,*)
       read (NUN,'(i4,i4)')  NSS, NSX_
       read (NUN,*)
-      write(6,'(i6,a)') NSS, ' types of strat sulf aerosols'
+      if (AMIROOT) write(6,'(i6,a)') NSS, ' types of strat sulf aerosols'
       do K = 1,NSS
 !SJ! *** the SSA file for LCLIRAD in SJ has different format  '(a12, 3f8,4,...
          read (NUN,'(a10, 3f8.4, 2f8.1)')    &
               TITLSS(K),RSS(K),GSS(K),DSS(K),TSS(K),WSS(K)
-         write(6,'(i4,1x,a12,2f10.4,2f8.1)') K,TITLSS(K),RSS(K),DSS(K),&
+         if (AMIROOT) write(6,'(i4,1x,a12,2f10.4,2f8.1)') K,TITLSS(K),RSS(K),DSS(K),&
                TSS(K),WSS(K)
          do J = 5, NSX_
             read(NUN,'(i2,2f8.4,e8.1,2f8.5,7f6.3)')      &
@@ -651,7 +655,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_MIE(NUN,NAMFIL)
+      subroutine RD_MIE(AMIROOT,NUN,NAMFIL)
 !-----------------------------------------------------------------------
 !-------aerosols scattering data set for fast-JX ver 7.3+
 !-----------------------------------------------------------------------
@@ -667,6 +671,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
 
@@ -677,13 +682,13 @@
       Character*12 TITLAAJ
       real*8   RAAJ, DAAJ
 
-      write(6,'(i5,a)') NUN,trim(NAMFIL)
+      if (AMIROOT) write(6,'(i5,a)') NUN,trim(NAMFIL)
 
       open (NUN,FILE=NAMFIL,status='old',form='formatted',err=4)
 
       read (NUN,'(a120)',err=4) TITLE0
 
-      write(6,'(a)') adjustl(trim(TITLE0))
+      if (AMIROOT) write(6,'(a)') adjustl(trim(TITLE0))
       read (NUN,*)
       read (NUN,*)
       do J = 1, A_
@@ -705,7 +710,7 @@
                PAA(1,K,J) = 1.d0
             enddo
             NAA = J
-            write(6,'(i5,1x,a12,1x,7f9.3,1x,a)')   &
+            if (AMIROOT) write(6,'(i5,1x,a12,1x,7f9.3,1x,a)')   &
                   J,TITLAAJ,RAAJ,DAAJ,(QAA(K,J),K=1,5),trim(TITLE0)
          else
             goto 2
@@ -725,7 +730,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_UM(NUN,NAMFIL)
+      subroutine RD_UM(AMIROOT,NUN,NAMFIL)
 !-----------------------------------------------------------------------
 !-------UMich aerosol optical data for fast-JX (ver 6.1+)
 !-----------------------------------------------------------------------
@@ -734,6 +739,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
 
@@ -744,9 +750,9 @@
       open (NUN,FILE=NAMFIL,status='old',form='formatted')
 
       read (NUN,'(a78)') TITLE0
-      write(6,*) 'UMichigan Aerosols ', adjustl(trim(TITLE0))
+      if (AMIROOT) write(6,*) 'UMichigan Aerosols ', adjustl(trim(TITLE0))
       read(NUN,'(5x,10f5.0)') WMM
-      write(6,'(a,10f7.1)') ' UMIchigan aerosol wavelengths:',WMM
+      if (AMIROOT) write(6,'(a,10f7.1)') ' UMIchigan aerosol wavelengths:',WMM
 
 !---33 Different UM Aerosol Types:  SULF, SS-1,-2,-3,-4, DD-1,-2,-3,-4,
 !---      FF00(0%BC), FF02, ...FF14(14%BC),  BB00, BB02, ...BB30(30%BC)
@@ -760,7 +766,7 @@
          enddo
       enddo
       close(NUN)
-      write(6,'(a)') 'collapse UM wavelengths, drop 550 nm'
+      if (AMIROOT) write(6,'(a)') 'collapse UM wavelengths, drop 550 nm'
       WMM(4) = WMM(5)
       WMM(5) = WMM(6)
       do L=1,33
@@ -772,18 +778,19 @@
          enddo
       enddo
 
-      write(6,'(7(i5,1x,a4))') (L,TITLUM(L), L=1,33)
+      if (AMIROOT) write(6,'(7(i5,1x,a4))') (L,TITLUM(L), L=1,33)
 
       END SUBROUTINE RD_UM
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_PROF(NJ2,NAMFIL)
+      subroutine RD_PROF(AMIROOT,NJ2,NAMFIL)
 !-----------------------------------------------------------------------
 !  Routine to input T and O3 reference profiles 'atmos_std.dat'
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in) :: AMIROOT
       integer, intent(in) ::  NJ2
       character(*), intent(in) ::  NAMFIL
 !
@@ -796,7 +803,7 @@
       read (NJ2,'(A)') TITLE0
       read (NJ2,'(2I5)') NTLATS,NTMONS
 !      write(6,'(1X,A)') TITLE0
-      write(6,1000) NTLATS,NTMONS
+      if (AMIROOT) write(6,1000) NTLATS,NTMONS
       N216  = min(216, NTLATS*NTMONS)
       do IA = 1,N216
         read (NJ2,'(1X,I3,3X,I2)') LAT, MON
@@ -836,12 +843,13 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_TRPROF(NJ2,NAMFIL)
+      subroutine RD_TRPROF(AMIROOT,NJ2,NAMFIL)
 !-----------------------------------------------------------------------
 !  Routine to input H2O and CH4 reference profiles 'atmos_h2och4.dat'
 !-----------------------------------------------------------------------
       implicit none
 
+      logical, intent(in) :: AMIROOT
       integer, intent(in) ::  NJ2
       character(*), intent(in) ::  NAMFIL
 !
@@ -853,7 +861,7 @@
       read (NJ2,'(A)') TITLE0
       read (NJ2,'(2I5)') NTLATS,NTMONS
 !      write(6,'(1X,A)') TITLE0
-      write(6,1000) NTLATS,NTMONS
+      if (AMIROOT) write(6,1000) NTLATS,NTMONS
       N216  = min(216, NTLATS*NTMONS)
       do IA = 1,N216
         read (NJ2,'(1X,I3,3X,I2)') LAT, MON
@@ -885,7 +893,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_JS_JX(NUNIT,NAMFIL,TITLEJX,NJX)
+      subroutine RD_JS_JX(AMIROOT,NUNIT,NAMFIL,TITLEJX,NJX)
 !-----------------------------------------------------------------------
 !  Read 'FJX_j2j.dat' that defines mapping of fast-JX J's (TITLEJX(1:NJX))
 !    onto the CTM reactions:  react# JJ, named T_REACT, uses fast-JX's JVMAP
@@ -902,6 +910,7 @@
 !-----------------------------------------------------------------------
       implicit none
 !
+      logical, intent(in) :: AMIROOT
       integer, intent(in)                    ::  NUNIT, NJX
       character(*), intent(in)               ::  NAMFIL
       character*6, intent(in),dimension(NJX) :: TITLEJX
@@ -924,7 +933,7 @@
       open (NUNIT,file=NAMFIL,status='old',form='formatted')
 
        read (NUNIT,'(a)') CLINE
-         write(6,'(a)') CLINE
+         if (AMIROOT) write(6,'(a)') CLINE
       do J = 1,JVN_
        read (NUNIT,'(i4,1x,a50,4x,f5.3,2x,a6)') JJ,T_REACT,F_FJX,T_FJX
        if (JJ .gt. JVN_) exit
@@ -961,15 +970,15 @@
        enddo
       enddo
 
-      write(6,'(a,i4,a)')' Photochemistry Scheme with',NRATJ,' J-values'
+      if (AMIROOT) write(6,'(a,i4,a)')' Photochemistry Scheme with',NRATJ,' J-values'
       do K=1,NRATJ
        if (JVMAP(K) .ne. '------' ) then
         J = JIND(K)
         if (J.eq.0) then
-         write(6,'(i5,1x,a50,f6.3,a,1x,a6)') K,JLABEL(K),JFACTA(K), &
+         if (AMIROOT) write(6,'(i5,1x,a50,f6.3,a,1x,a6)') K,JLABEL(K),JFACTA(K), &
                ' no mapping onto fast-JX',JVMAP(K)
         else
-         write(6,'(i5,1x,a50,f6.3,a,i4,1x,a6)') K,JLABEL(K),JFACTA(K), &
+         if (AMIROOT) write(6,'(i5,1x,a50,f6.3,a,i4,1x,a6)') K,JLABEL(K),JFACTA(K), &
                ' mapped to FJX:',J,TITLEJX(J)
         endif
        endif
@@ -980,7 +989,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_GEO(NUN,NAMFIL)
+      subroutine RD_GEO(AMIROOT,NUN,NAMFIL)
 !-----------------------------------------------------------------------
 !-------GEOMIP SSA scattering data set for fast-JX ver 7.5 ONLY RRTMG 27 bins
 !-----------------------------------------------------------------------
@@ -994,6 +1003,7 @@
 !     PGG      Phase function: first 8 terms of expansion
 !-----------------------------------------------------------------------
       implicit none
+      logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
 
@@ -1004,14 +1014,14 @@
       open (NUN,FILE=NAMFIL,status='old',form='formatted',err=4)
 
       read (NUN,'(a120)',err=4) TITLE0
-      write(6,'(a)') trim(TITLE0)
+      if (AMIROOT) write(6,'(a)') trim(TITLE0)
       read (NUN,'(i4)')  NGG
-      write(6,'(i6,a)')  NGG, ' Reff-s for GEO SSA'
+      if (AMIROOT) write(6,'(i6,a)')  NGG, ' Reff-s for GEO SSA'
       read (NUN,*)
       read (NUN,*)
       do K = 1,NGG
          read(NUN,'(10x,5f8.4)') RGG(K),G1,DGG(K),G2,G3
-         write(6,'(i4,1x,3f8.4,2f8.1)') K,RGG(K),DGG(K), G1,G2,G3
+         if (AMIROOT) write(6,'(i4,1x,3f8.4,2f8.1)') K,RGG(K),DGG(K), G1,G2,G3
          do J = 5, 27
             read (NUN,'(2x,2f8.4,e8.1,2f8.5,7f6.3)',err=4) &
                  WGGJ,XNDR,XNDI,QGG(J,K),SGG(J,K),(PGG(I,J,K),I=2,8)
@@ -1040,13 +1050,14 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine RD_SSAPROF(NJ2,NAMFIL)
+      subroutine RD_SSAPROF(AMIROOT,NJ2,NAMFIL)
 !-----------------------------------------------------------------------
 !  Routine to input SSA-GEO reference profiles for 'atmos_geomip.dat'
 !      R_GEO = effective radius (microns)
 !      X_GEO = mass fraction (1e-9 kg-H2SO4/kg-air)
 !-----------------------------------------------------------------------
       implicit none
+      logical, intent(in) :: AMIROOT
       integer, intent(in) ::  NJ2
       character(*), intent(in) ::  NAMFIL
 !
@@ -1055,24 +1066,24 @@
 !
       open (NJ2,file=NAMFIL,status='old',form='formatted')
       read (NJ2,'(a)') TITLE0
-         write(6,'(1x,a)') TITLE0
+         if (AMIROOT) write(6,'(1x,a)') TITLE0
       read (NJ2,*)
       read (NJ2,*)
 ! only specify 19 pressure levels from 2.7 hPa to 340 hPa
       read (NJ2,'(19f7.2)') (P_GREF(L),L=1,19)
-      write(6,'(19f7.2)')(P_GREF(L),L=1,19)
+      if (AMIROOT) write(6,'(19f7.2)')(P_GREF(L),L=1,19)
       read (NJ2,*)
       read (NJ2,*)
       read (NJ2,*)
 ! latitude bins 1:36 are Gauss, but approx 1.3953 + (J-33)*2.7906 deg
       read (NJ2,'(32f5.1)') (Y_GREF(L),L=1,32)
-      write (6,'(32f5.1)') (Y_GREF(L),L=1,32)
+      if (AMIROOT) write (6,'(32f5.1)') (Y_GREF(L),L=1,32)
 
       read (NJ2,*)
       read (NJ2,'(32f5.1)') (Y_GREF(L),L=64,33,-1)
-      write (6,'(32f5.1)') (Y_GREF(L),L=33,64)
+      if (AMIROOT) write (6,'(32f5.1)') (Y_GREF(L),L=33,64)
       read (NJ2,'(a)') TITLE0
-         write(6,'(1x,a)') TITLE0
+         if (AMIROOT) write(6,'(1x,a)') TITLE0
       do M = 1,12
           read (NJ2,*)
         do J = 1,64
@@ -1081,7 +1092,7 @@
         enddo
       enddo
       read (NJ2,'(a)') TITLE0
-         write(6,'(1x,a)') TITLE0
+         if (AMIROOT) write(6,'(1x,a)') TITLE0
       do M = 1,12
           read (NJ2,*)
         do J = 1,64
@@ -1090,7 +1101,7 @@
         enddo
       enddo
       read (NJ2,'(a)') TITLE0
-         write(6,'(1x,a)') TITLE0
+         if (AMIROOT) write(6,'(1x,a)') TITLE0
       do M = 1,12
           read (NJ2,*)
         do J = 1,64


### PR DESCRIPTION
This pull request adds a logical argument to the Cloud-J initialization subroutines to enable printing informational messages from one core only. This is a zero diff update. It should be merged in at the same time as https://github.com/geoschem/geos-chem/pull/2109.