### PR TITLE
Set levels with cloud from parent model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the Cloud-J repository since the init
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.7.2] - TBD
+### Changed
+- Changed hard-coding LWEPAR in cldj_cmn_mod to be passed from parent model unless using standalone
+
+### Added
+- Added CLOUDJ_STANDALONE c-proprocessor switch to generalize code to use instead within a parent model
+
 ## [7.7.1] - 2024-04-02
 ### Changed
 - Changed arguments of Init_Cldj to include root thread logical and LUT data directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if(NOT CLOUDJ_EXTERNAL_CONFIG)
 
     # Set Cloud-J compile flag to standalone
     target_compile_definitions(CloudJBuildProperties
-        INTERFACE "CloudJ_Standalone"
+        INTERFACE CLOUDJ_STANDALONE
     )
 
     # Set CMAKE_BUILD_TYPE to Release by default

--- a/src/Core/cldj_cmn_mod.F90
+++ b/src/Core/cldj_cmn_mod.F90
@@ -23,14 +23,14 @@
 
       ! Can be changed as needed. Must be exact atmospheric dimensions.
 
-#ifdef MODEL_GEOSCHEM
-      integer :: L_    !  # of CTM layers, set at run-time
-      integer :: L1_   !  L_+1 = # of CTM layer edges (radii)
-      integer :: L2_   !  L_+2 = total # of layer edges counting top (TAU=0)
+#ifdef CLOUDJ_STANDALONE
+      integer, parameter :: L_  = 57    !  # of CTM layers, set at build-time
+      integer, parameter :: L1_ = L_+1  !  L_+1 = # of CTM layer edges (radii)
+      integer, parameter :: L2_ = L_+2  !  L_+2 = total # of layer edges counting top (TAU=0)#
 #else
-      integer, parameter :: L_  = 57   !  # of CTM layers, set at build-time
-      integer, parameter :: L1_ = L_+1 !  L_+1 = # of CTM layer edges (radii)
-      integer, parameter :: L2_ = L_+2 !  L_+2 = total # of layer edges counting top (TAU=0)
+      integer :: L_     !  # of CTM layers, set at run-time
+      integer :: L1_    !  L_+1 = # of CTM layer edges (radii)
+      integer :: L2_    !  L_+2 = total # of layer edges counting top (TAU=0)
 #endif
 
       !  # layers that have clouds (LWEPAR < L_)
@@ -46,14 +46,14 @@
       ! JVN_ :  max # of J-values
 #ifdef MODEL_GEOSCHEM
       integer, parameter :: JVN_ = 166
-#else
+#elif CLOUDJ_STANDALONE
       integer, parameter :: JVN_ = 101
 #endif
 
       ! mAN_ :  max # FJX aerosols in layer (needs NDX for each)
 #ifdef MODEL_GEOSCHEM
       integer, parameter :: AN_=37
-#else
+#elif CLOUDJ_STANDALONE
       integer, parameter :: AN_=25
 #endif
 
@@ -94,7 +94,7 @@
       ! X_   = dim = max no. of X-section data sets (input data)
 #ifdef MODEL_GEOSCHEM
       integer, parameter ::  X_=123
-#else
+#elif CLOUDJ_STANDALONE
       integer, parameter ::  X_=72
 #endif
 
@@ -102,7 +102,7 @@
       !        clouds and SSA
 #ifdef MODEL_GEOSCHEM
       integer, parameter ::  A_=56
-#else
+#elif CLOUDJ_STANDALONE
       integer, parameter ::  A_=40
 #endif
 

--- a/src/Core/cldj_cmn_mod.F90
+++ b/src/Core/cldj_cmn_mod.F90
@@ -47,6 +47,8 @@
       integer, parameter :: JVN_ = 166
 #elif CLOUDJ_STANDALONE
       integer, parameter :: JVN_ = 101
+#else
+#error "Invalid model selection: parameters only defined for CLOUDJ_STANDALONE and MODEL_GEOSCHEM. Add parameters for additional models in cldj_cmn_mod.F90."
 #endif
 
       ! mAN_ :  max # FJX aerosols in layer (needs NDX for each)

--- a/src/Core/cldj_cmn_mod.F90
+++ b/src/Core/cldj_cmn_mod.F90
@@ -27,14 +27,13 @@
       integer, parameter :: L_  = 57    !  # of CTM layers, set at build-time
       integer, parameter :: L1_ = L_+1  !  L_+1 = # of CTM layer edges (radii)
       integer, parameter :: L2_ = L_+2  !  L_+2 = total # of layer edges counting top (TAU=0)#
+      integer, parameter :: LWEPAR = 34 !  # layers that have clouds (LWEPAR < L_)
 #else
       integer :: L_     !  # of CTM layers, set at run-time
       integer :: L1_    !  L_+1 = # of CTM layer edges (radii)
       integer :: L2_    !  L_+2 = total # of layer edges counting top (TAU=0)
+      integer :: LWEPAR !  # layers that have clouds (LWEPAR < L_)
 #endif
-
-      !  # layers that have clouds (LWEPAR < L_)
-      integer, parameter :: LWEPAR = 34        
 
 !------------------------------------------------------------------------------
 ! Additional parameters

--- a/src/Core/cldj_cmn_mod.F90
+++ b/src/Core/cldj_cmn_mod.F90
@@ -51,7 +51,7 @@
 #error "Invalid model selection: parameters only defined for CLOUDJ_STANDALONE and MODEL_GEOSCHEM. Add parameters for additional models in cldj_cmn_mod.F90."
 #endif
 
-      ! mAN_ :  max # FJX aerosols in layer (needs NDX for each)
+      ! AN_ :  max # FJX aerosols in layer (needs NDX for each)
 #ifdef MODEL_GEOSCHEM
       integer, parameter :: AN_=37
 #elif CLOUDJ_STANDALONE

--- a/src/Core/cldj_init_mod.F90
+++ b/src/Core/cldj_init_mod.F90
@@ -46,7 +46,7 @@
 
       if (AMIROOT) write(6,*) ' Solar/Cloud-J  ver-7.7 initialization'
 
-#ifndef CLOUDJ_STANDALONE )
+#ifndef CLOUDJ_STANDALONE
       ! Set cldj_cmn_mod variables based on input numbers of levels
       L_    = NLEVELS
       L1_   = L_ + 1

--- a/src/Core/cldj_init_mod.F90
+++ b/src/Core/cldj_init_mod.F90
@@ -28,13 +28,15 @@
       CONTAINS
 
 !-----------------------------------------------------------------------
-      subroutine INIT_CLDJ (AMIROOT,DATADIR,NLEVELS,TITLEJXX,NJXU,NJXX)
+      subroutine INIT_CLDJ (AMIROOT,DATADIR,NLEVELS,NLEVELS_WITH_CLOUD, &
+                            TITLEJXX,NJXU,NJXX)
 !-----------------------------------------------------------------------
       implicit none
 
       logical, intent(in)          :: AMIROOT
       character(LEN=*), intent(in) :: DATADIR
       integer, intent(in)          :: NLEVELS
+      integer, intent(in)          :: NLEVELS_WITH_CLOUD
       integer, intent(in)          :: NJXU
       integer, intent(out)         :: NJXX
       character*6, intent(out), dimension(NJXU) :: TITLEJXX
@@ -44,11 +46,12 @@
 
       if (AMIROOT) write(6,*) ' Solar/Cloud-J  ver-7.7 initialization'
 
-#if defined ( MODEL_GEOSCHEM )
+#ifndef CLOUDJ_STANDALONE )
       ! Set cldj_cmn_mod variables based on input numbers of levels
       L_    = NLEVELS
       L1_   = L_ + 1
       L2_   = L_ + 2
+      LWEPAR= NLEVELS_WITH_CLOUD
 #endif
 
       JVL_  = L_

--- a/src/Interfaces/Standalone/CJ77.F90
+++ b/src/Interfaces/Standalone/CJ77.F90
@@ -67,7 +67,7 @@
       amIRoot = .true.
 !---read in & store all fast-JX data:   single call at set up
 !-----------------------------------------------------------------------      
-      call INIT_CLDJ (amIRoot,'./tables/',NLEVELS,TITLJXX,JVNU,NJXX)
+      call INIT_CLDJ (amIRoot,'./tables/',NLEVELS,LWEPAR,TITLJXX,JVNU,NJXX)
 !-----------------------------------------------------------------------
 
 !--P, T, Cld & Aersl profiles, simple test input case


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR changes Cloud-J so that parameter LWEPAR (# levels with cloud) is passed from the parent model if not using Cloud-J standalone. This enables using Cloud-J in parent models with different vertical grids.

This update also more generalizes the condition in which vertical level information is passed from the parent model. Previously total number of vertical levels could only be set from the parent if using GEOS-Chem. New C-preprocessor switch CLOUDJ_STANDALONE allows removing MODEL_GEOSCHEM for that section.

### Expected changes

This is a zero diff update for GEOS-Chem benchmarks.

### Reference(s)

none

### Related Github Issues and PRs

closes https://github.com/geoschem/Cloud-J/issues/16
https://github.com/geoschem/geos-chem/pull/2342 **(merge required for compatibility with this PR)**
