### PR TITLE
Mac build

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,8 +2,6 @@ name: Mac
 
 on: 
   push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,6 +2,8 @@ name: Mac
 
 on: 
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,34 @@
+name: Mac
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  gnu:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        gcc_version: [11, 12, 13]
+        build_type: [Debug, Release]
+    env:
+      FC: gfortran-${{ matrix.gcc_version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install netcdf netcdf-fortran
+
+      - name: Run Cmake
+        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+      - name: Build
+        run: cmake --build build  --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed FJX_scat-aer.dat format to expect 1 character greater width for PAA (data columns 3-9)
 - Limit prints to single core
 - Renamed all modules to use .F90 suffix and cldj_ prefix
+- Modified the cmake files for Standalone to build on mac successfully
 
 ## Added
 - Added CMake support
@@ -21,7 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added C pre-processor blocks for compatibility with GEOS-Chem offline CTM, GCHP, GEOS, and CESM
 - Added new global variables RNAMES and BRANCH for species info
 - Added GitHub config and PR/issue templates
-- Added GitHub action for build tests
+- Added GitHub action to test builds on Ubuntu
+- Added GitHub action to test builds on Mac
 
 ### Fixed
 - Fixed bugs for compatibility with gfortran compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(CloudJ_Fortran_FLAGS_DEBUG_Intel
 
 set(CloudJ_Fortran_FLAGS_GNU
    -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
-   -fno-range-check -mcmodel=medium -fbacktrace -g -DLINUX_GFORTRAN
+   -fno-range-check -mcmodel=small -fbacktrace -g -DLINUX_GFORTRAN
    -ffree-line-length-none
    CACHE STRING "Cloud-J compiler flags for all build types with GNU compilers"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,12 +62,23 @@ set(CloudJ_Fortran_FLAGS_DEBUG_Intel
    CACHE STRING "Cloud-J compiler flags for build type debug with Intel compilers"
 )
 
-set(CloudJ_Fortran_FLAGS_GNU
-   -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
-   -fno-range-check -mcmodel=small -fbacktrace -g -DLINUX_GFORTRAN
-   -ffree-line-length-none
-   CACHE STRING "Cloud-J compiler flags for all build types with GNU compilers"
-)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    # arm based processors only support mcmodels of large small tiny
+    set(CloudJ_Fortran_FLAGS_GNU
+        -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
+        -fno-range-check -mcmodel=small -fbacktrace -g -DLINUX_GFORTRAN
+        -ffree-line-length-none
+        CACHE STRING "Cloud-J compiler flags for all build types with GNU compilers"
+    )
+else()
+    set(CloudJ_Fortran_FLAGS_GNU
+        -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
+        -fno-range-check -mcmodel=medium -fbacktrace -g -DLINUX_GFORTRAN
+        -ffree-line-length-none
+        CACHE STRING "Cloud-J compiler flags for all build types with GNU compilers"
+    )
+endif()
+
 set(CloudJ_Fortran_FLAGS_RELEASE_GNU
    -O3 -funroll-loops
    CACHE STRING "Cloud-J compiler flags for build type release with GNU compilers"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cloud-J
 
 [![Ubuntu](https://github.com/geoschem/Cloud-J/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/geoschem/Cloud-J/actions/workflows/ubuntu.yml)
+[![Mac](https://github.com/geoschem/Cloud-J/actions/workflows/mac.yml/badge.svg)](https://github.com/geoschem/Cloud-J/actions/workflows/mac.yml)
 [![License](https://img.shields.io/badge/license-GPLv3-blue)](https://github.com/geoschem/Cloud-J/blob/main/LICENSE)
 
 Cloud-J is a multi-scattering eight-stream radiative transfer model for solar radiation based on Fast-J. It was originally developed by Michael J. Prather (UCI). For information about the origins and history of Cloud-J and its predecessor Fast-J please see the [history document](https://github.com/geoschem/cloud-j/blob/main/docs/History_of_Fast-J_photolysis_code.md) in the docs subdirectory of this repository.

--- a/src/Interfaces/Standalone/CMakeLists.txt
+++ b/src/Interfaces/Standalone/CMakeLists.txt
@@ -1,26 +1,11 @@
 # Cloud-J/src/CMakeLists.txt
 
-add_library(CloudJ_Standalone STATIC EXCLUDE_FROM_ALL
-	CJ77.F90
-)
-target_link_libraries(CloudJ_Standalone
-	PUBLIC CloudJ_Core
-)
-target_include_directories(CloudJ_Standalone
-        INTERFACE ${CLOUDJ_BINARY_DIR}/mod
-)
-target_compile_options(CloudJ_Standalone
-        PRIVATE
-                ""
-                $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","GNU">:-ffree-line-length-none>
-)
-
 #if("cloudj_standalone" IN_LIST CLOUDJ_EXE_TARGETS)
         add_executable(cloudj_standalone
                 CJ77.F90
         )
         target_link_libraries(cloudj_standalone
-                PUBLIC CloudJ_Standalone
+                PUBLIC CloudJ_Core
         )
         set_target_properties(cloudj_standalone PROPERTIES
                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Kyle Shores
Institution: National Center for Atmospheric Research

### Describe the update

Adds a github action to build CloudJ on mac with gcc 11, 12, and 13. Some of the cmake files also had to be modified to make it work

### Expected changes

There shouldn't be any since there were no code changes. However, when I run the standalone binary, I get a segfault on mac

### Reference(s)

None

### Related Github Issues and PRs

None
