### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - Added CLOUDJ_STANDALONE c-proprocessor switch to generalize code to use instead within a parent model
+- Added integer status flag RC to most subroutines and pass it back up to parent model with error messages
+- Added subroutine CLOUDJ_ERROR to print error message and set integer status flag RC
+
+### Removed
+- Removed subroutine EXITC and replaced it with CLOUDJ_ERROR_STOP in standalone and CLOUDJ_ERROR elsewhere
 
 ## [7.7.1] - 2024-04-02
 ### Changed

--- a/src/Core/cldj_error_mod.F90
+++ b/src/Core/cldj_error_mod.F90
@@ -2,6 +2,7 @@ MODULE CLDJ_ERROR_MOD
 
   IMPLICIT NONE
 
+  PUBLIC  :: CLOUDJ_ERROR
   PUBLIC  :: CLOUDJ_ERROR_STOP
   PUBLIC  :: SAFE_DIV
 
@@ -44,7 +45,7 @@ CONTAINS
   end subroutine CLOUDJ_ERROR_STOP
 
   !-----------------------------------------------------------------------
-  subroutine CLDJ_ERROR( errmsg, loc, rc )
+  subroutine CLOUDJ_ERROR( errmsg, loc, rc )
 
 #if defined( MODEL_CESM )
     USE CAM_ABORTUTILS, ONLY : ENDRUN
@@ -86,7 +87,7 @@ CONTAINS
        rc = CLDJ_FAILURE
     ENDIF
 
-  end subroutine CLDJ_ERROR
+  end subroutine CLOUDJ_ERROR
 
   !-----------------------------------------------------------------------
   function SAFE_DIV( numer, denom, alt_nan, alt_overflow, alt_underflow ) &

--- a/src/Core/cldj_error_mod.F90
+++ b/src/Core/cldj_error_mod.F90
@@ -1,99 +1,146 @@
-! INTERFACE:
+MODULE CLDJ_ERROR_MOD
 
-      MODULE CLDJ_ERROR_MOD
+  IMPLICIT NONE
 
-      IMPLICIT NONE
+  PUBLIC  :: CLOUDJ_ERROR_STOP
+  PUBLIC  :: SAFE_DIV
 
-      PUBLIC  :: CLOUDJ_ERROR_STOP
-      PUBLIC  :: SAFE_DIV
+  INTEGER, PUBLIC, PARAMETER :: CLDJ_SUCCESS =  0   ! Routine returns success
+  INTEGER, PUBLIC, PARAMETER :: CLDJ_FAILURE = -1   ! Routine returns failure
 
-      CONTAINS
+CONTAINS
 
-!-----------------------------------------------------------------------
-      subroutine CLOUDJ_ERROR_STOP( msg, loc )
-      ! This subroutine...
+  !-----------------------------------------------------------------------
+  subroutine CLOUDJ_ERROR_STOP( errmsg, loc )
 
-      ! This subroutine is based on the equivalent function in GEOS-Chem
-      ! (https://github.com/geoschem/geos-chem).
-!-----------------------------------------------------------------------
 #if defined( MAPL_ESMF )
 #include "MAPL_Generic.h"
-      USE MAPLBase_Mod
+    USE MAPLBase_Mod
 #elif defined( MODEL_CESM )
-      ! if using cesm
-      USE CAM_ABORTUTILS,     ONLY : ENDRUN
+    USE CAM_ABORTUTILS,     ONLY : ENDRUN
 #endif
 
-      character(len=*), intent(in)           :: msg
-      character(len=*), intent(in), optional :: loc
+    character(len=*), intent(in) :: errmsg
+    character(len=*), intent(in) :: loc
 
-      character(len=512) :: tmpmsg
+    character(len=1023) :: msg
 
+    ! Define message
+    msg = 'CLOUDJ_ERROR_STOP: '//TRIM(errmsg)//' --> LOCATION: '//TRIM(loc)
+
+    ! Stop run
 #if defined( MAPL_ESMF )
-      __Iam__('CLOUDJ_ERROR_STOP')
+    __Iam__(msg)
 #elif defined( MODEL_CESM )
-      call endrun('Cloud-J failure!')
-#elif defined( MODEL_GEOSCHEM )
-      call exit( 99999 )
+    call endrun(msg)
+#elif defined( MODEL_GCCLASSIC )
+    WRITE(6,*) TRIM(msg)
+    call exit( 99999 )
 #else
-      stop
+    WRITE(*,*) TRIM(msg)
+    stop
 #endif
 
-      end subroutine CLOUDJ_ERROR_STOP
+  end subroutine CLOUDJ_ERROR_STOP
 
-!-----------------------------------------------------------------------
-      function SAFE_DIV( numer, denom, alt_nan, alt_overflow, alt_underflow ) &
+  !-----------------------------------------------------------------------
+  subroutine CLDJ_ERROR( errmsg, loc, rc )
+
+#if defined( MODEL_CESM )
+    USE CAM_ABORTUTILS, ONLY : ENDRUN
+#elif MAPL_ESMF
+#include "MAPL_Generic.h"
+    USE ESMF
+    USE MAPL_Mod
+#endif
+
+    CHARACTER(LEN=*), INTENT(IN   )  :: errmsg  ! Message to display
+    CHARACTER(LEN=*), INTENT(IN   )  :: loc     ! Location of error
+    INTEGER,          INTENT(INOUT)  :: rc      ! Error code
+
+    CHARACTER(LEN=1023) :: msg
+#if defined( MAPL_ESMF )
+    INTEGER             :: localPET, status
+    CHARACTER(4)        :: localPETchar
+    TYPE(ESMF_VM)       :: vm
+#endif
+
+#ifdef MAPL_ESMF
+    ! Get current thread number
+    CALL ESMF_VMGetCurrent(vm, RC=STATUS)
+    CALL ESMF_VmGet( vm, localPET=localPET, __RC__ )
+    WRITE(localPETchar,'(I4.4)') localPET
+    msg = 'CLOUDJ_ERROR ['//TRIM(localPETchar)//']: '//TRIM(errmsg) &
+         //' --> LOCATION: ' // TRIM(loc)
+    WRITE(*,*) TRIM(msg)
+#elif MODEL_CESM
+    CALL ENDRUN('CLOUDJ_ERROR: '//TRIM(errmsg)//' --> LOCATION: '//TRIM(loc))
+#else
+    msg = 'CLOUDJ_ERROR: '//TRIM(errmsg)// ' --> LOCATION: '//TRIM(loc)
+    WRITE(6,*) TRIM(msg)
+    CALL Flush( 6 )
+#endif
+
+    ! Return with failure, but preserve existing error code
+    IF ( rc == CLDJ_SUCCESS ) THEN
+       rc = CLDJ_FAILURE
+    ENDIF
+
+  end subroutine CLDJ_ERROR
+
+  !-----------------------------------------------------------------------
+  function SAFE_DIV( numer, denom, alt_nan, alt_overflow, alt_underflow ) &
        result( quot )
-      ! This funtion performs "safe division", that is to prevent overflow,
-      ! underlow, NaN, or infinity errors.  An alternate value is returned
-      ! if the division cannot be performed.
+    ! This funtion performs "safe division", that is to prevent overflow,
+    ! underlow, NaN, or infinity errors.  An alternate value is returned
+    ! if the division cannot be performed.
 
-      ! This function is based on the equivalent function in GEOS-Chem
-      ! (https://github.com/geoschem/geos-chem). 
-!-----------------------------------------------------------------------
+    ! This function is based on the equivalent function in GEOS-Chem
+    ! (https://github.com/geoschem/geos-chem). 
+    !-----------------------------------------------------------------------
 
-      ! Numerator and denominator
-      real*8, intent(in) :: numer
-      real*8, intent(in) :: denom
+    ! Numerator and denominator
+    real*8, intent(in) :: numer
+    real*8, intent(in) :: denom
 
-      ! Alternate value to be returned if the division is either NAN (0/0) or
-      ! leads to overflow (i.e., a too large number)
-      real*8, intent(in) :: alt_nan
+    ! Alternate value to be returned if the division is either NAN (0/0) or
+    ! leads to overflow (i.e., a too large number)
+    real*8, intent(in) :: alt_nan
 
-      ! Alternate value to be returned if the division leads to overflow
-      ! (default is ALT_NAN)
-      real*8, optional, intent(in) :: alt_overflow
- 
-      ! Alternate value to be returned if the division leads to underflow
-      ! (default is 0, but you could use TINY() if you want a non-zero result).
-      real*8, optional, intent(in) :: alt_underflow
+    ! Alternate value to be returned if the division leads to overflow
+    ! (default is ALT_NAN)
+    real*8, optional, intent(in) :: alt_overflow
 
-      ! Return value is output from division
-      real*8 :: quot
+    ! Alternate value to be returned if the division leads to underflow
+    ! (default is 0, but you could use TINY() if you want a non-zero result).
+    real*8, optional, intent(in) :: alt_underflow
 
-      ! NaN
-      if ( numer == 0 .and. denom == 0 ) THEN
-         quot = alt_nan
+    ! Return value is output from division
+    real*8 :: quot
 
-      ! Overflow
-      else if ( EXPONENT(numer) - EXPONENT(denom) >= MAXEXPONENT(numer) &
-                .OR. Denom == 0 ) then
-         quot = alt_nan
-         if ( PRESENT(alt_overflow) ) quot = alt_overflow
+    ! NaN
+    if ( numer == 0 .and. denom == 0 ) THEN
+       quot = alt_nan
 
-      ! Underflow
-      else if ( EXPONENT(numer) - EXPONENT(denom) <= MINEXPONENT(numer) ) then
+       ! Overflow
+    else if ( EXPONENT(numer) - EXPONENT(denom) >= MAXEXPONENT(numer) &
+         .OR. Denom == 0 ) then
+       quot = alt_nan
+       if ( PRESENT(alt_overflow) ) quot = alt_overflow
 
-         quot = 0D0
-         if ( PRESENT(alt_underflow) ) quot = alt_underflow
-  
-      else
-  
-         ! No problem
-         quot = numer / denom
-  
-      endif
+       ! Underflow
+    else if ( EXPONENT(numer) - EXPONENT(denom) <= MINEXPONENT(numer) ) then
 
-      end function SAFE_DIV
+       quot = 0D0
+       if ( PRESENT(alt_underflow) ) quot = alt_underflow
 
-      END MODULE CLDJ_ERROR_MOD
+    else
+
+       ! No problem
+       quot = numer / denom
+
+    endif
+
+  end function SAFE_DIV
+
+END MODULE CLDJ_ERROR_MOD

--- a/src/Core/cldj_error_mod.F90
+++ b/src/Core/cldj_error_mod.F90
@@ -25,13 +25,17 @@ CONTAINS
     character(len=*), intent(in) :: loc
 
     character(len=1023) :: msg
+#if defined( MAPL_ESMF )
+    integer :: rc
+#endif
 
     ! Define message
     msg = 'CLOUDJ_ERROR_STOP: '//TRIM(errmsg)//' --> LOCATION: '//TRIM(loc)
 
     ! Stop run
 #if defined( MAPL_ESMF )
-    __Iam__(msg)
+    RC = CLDJ_FAILURE
+    _ASSERT(RC==CLDJ_SUCCESS,TRIM(msg))
 #elif defined( MODEL_CESM )
     call endrun(msg)
 #elif defined( MODEL_GCCLASSIC )
@@ -52,7 +56,7 @@ CONTAINS
 #elif MAPL_ESMF
 #include "MAPL_Generic.h"
     USE ESMF
-    USE MAPL_Mod
+    USE MAPLBase_Mod
 #endif
 
     CHARACTER(LEN=*), INTENT(IN   )  :: errmsg  ! Message to display

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -138,7 +138,6 @@
 !    needs P, T, O3, clds, aersls; adds top-of-atmos layer from climatology
 !    needs day-of-year for sun distance, SZA (not lat or long)
 !-----------------------------------------------------------------------
-      implicit none
 
 !---calling sequence variables
       real*8,  intent(in)                    :: U0    ! cloud-j input
@@ -859,7 +858,6 @@
       subroutine OPMIE (DTAUX,POMEGAX,U0,RFL,AMF,AMG,JXTRA, &
               FJACT,FJTOP,FJBOT,FIBOT,FSBOT,FJFLX,FLXD,FLXD0, LDOKR,LU)
 !-----------------------------------------------------------------------
-      implicit none
 
       real*8, intent(in)  ::  DTAUX(L1_,W_+W_r),POMEGAX(M2_,L1_,W_+W_r)
       real*8, intent(in)  ::  AMF(L1_+1,L1_+1),AMG(L1_)
@@ -1264,7 +1262,6 @@
 !-----------------------------------------------------------------------
       subroutine MIESCT(FJ,FJT,FJB,FIB, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND)
 !-----------------------------------------------------------------------
-      implicit none
 
       integer, intent(in)  ::  LDOKR(W_+W_r),ND
       real*8,  intent(in)  ::  POMEGA(M2_,N_,W_+W_r),FZ(N_,W_+W_r), &
@@ -1318,7 +1315,7 @@
 !-----------------------------------------------------------------------
 !---Calculates ORDINARY Legendre fns of X (real)
 !---   from P[0] = PL(1) = 1,  P[1] = X, .... P[N-1] = PL(N)
-      implicit none
+
       integer, intent(in) :: N
       real*8, intent(in)  :: X
       real*8, intent(out) :: PL(N)
@@ -1348,7 +1345,6 @@
 !  This goes back to the old, dumb, fast version 5.3
 !-----------------------------------------------------------------------
 !SJ!      USE IEEE_ARITHMETIC
-      implicit none
 
       integer, intent(in) ::  LDOKR(W_+W_r),ND
       real*8, intent(in)  ::  POMEGA(M2_,N_,W_+W_r),FZ(N_,W_+W_r), &
@@ -1637,7 +1633,6 @@
 !  Generates coefficient matrices for the block tri-diagonal system:
 !               A(I)*X(I-1) + B(I)*X(I) + C(I)*X(I+1) = H(I)
 !-----------------------------------------------------------------------
-      implicit none
 
       integer, intent(in) ::  ND
       real*8, intent(in)  ::  POMEGA(M2_,N_),PM(M_,M2_),PM0(M2_)
@@ -1906,8 +1901,6 @@
 ! every S-bin has its own optical properties
 ! water clouds for (C1/Deir) GAMMA FN:alf=6  Reff from 1.5 to 48 microns
 
-      implicit none
-
       real*8, intent(in) ::    REFF         ! effective radius of liq water
 !cloud
       real*8, intent(in) ::    TEFF         ! effective temperature of ice
@@ -1951,8 +1944,6 @@
 ! new for FJ v7.5, parallel with liquid water, but two types of ice-water
 ! phase functions from a single calculation of Mishchenko, other opticals
 !     based on Mie calc. for liquid water to get best possible abosorption in IR
-
-      implicit none
 
       real*8, intent(in) ::    REFF         ! effective radius of liq water
 !cloud
@@ -2007,8 +1998,6 @@
 !>>> but the output OPTD, SSALB,SLEG now has a full SX-=27 wavelengths, not 5
 !(200-300-..-999mm)
 
-      implicit none
-
       real*8, intent(in)::     PATH         ! path (g/m2) of aerosol/cloud
       integer,intent(inout)::     K            ! index of cloud/aerosols
       real*8, intent(out)::    OPTD(S_)    ! optical depth of layer
@@ -2052,7 +2041,6 @@
 ! K = 1001:1015 corresponds to R-eff = 0.02 0.04 0.08 0.10 ...  1.4 2.0 3.0
 !5.0 microns
 !     output OPTD, SSALB,SLEG now has a full SX-=27 wavelengths
-      implicit none
 
       real*8, intent(in)::     PATH        ! path (g/m2) of aerosol/cloud
       integer,intent(in)::     K           ! index of cloud/aerosols
@@ -2087,7 +2075,7 @@
 !------------------------------------------------------------------------------
 !---v-7.6+ no StratSulfAers (use OPTICS)  also interp/extrap a 1/wavelength
 !         std 5 wavelengths:200-300-400-600-999nm
-        implicit none
+
         real*8, intent(out)::    OPTD(S_)    ! optical depth of layer
         real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
         real*8, intent(out)::    SLEG(8,S_)  ! scatt phase fn (Leg coeffs)
@@ -2159,7 +2147,6 @@
 !   K=1:21= [0, 5, 10, 15, ..., 90, 95, 99 %RelHum]
 !   L=1:33= UM aerosol types [SULF, SS-1,-2,-3,-4, DD-1,-2,-3,-4, FF00(0%BC),
 !                      FF02, ...FF14(14%BC), BB00, BB02, ...BB30(30%BC)]
-      implicit none
 
       real*8, intent(out)::    OPTD(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
@@ -2221,7 +2208,6 @@
 ! out:
 !        VALJL(L_,JX_)  JX_ = no of dimensioned J-values in CTM code
 !-----------------------------------------------------------------------
-      implicit none
 
       integer, intent(in)  :: LU,NJXU
       real*8, intent(in)  ::  PPJ(LU+1),TTJ(LU+1)
@@ -2303,7 +2289,6 @@
 !-----------------------------------------------------------------------
 !  up-to-three-point linear interpolation function for X-sections
 !-----------------------------------------------------------------------
-      implicit none
 
       real*8, intent(in)::  TINT,T1,T2,T3, X1,X2,X3
       integer,intent(in)::  L123
@@ -2335,7 +2320,7 @@
 !-----------------------------------------------------------------------
       subroutine JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU6,POMEG6,JXTRA,LU)
 !-----------------------------------------------------------------------
-      implicit none
+
 !-----------------------------------------------------------------------
 !---the CTM has L_ = LU layers and fast-JX adds layer LU+1
 !---the pressure and altitude(Z) are on layer edge (LU+2)
@@ -2379,7 +2364,7 @@
 !-----------------------------------------------------------------------
       subroutine JP_ATM0(PPJ,TTJ,DDJ,OOJ,ZZJ, LU)
 !-----------------------------------------------------------------------
-      implicit none
+
 !-----------------------------------------------------------------------
 !---Atmosphere print, called from outside fjx_sub_mod.f90
 !---CTM layers are 1:LU, + top layer (to P=0) added
@@ -2447,7 +2432,6 @@
 !     ZHL(L1U+1) = top radius of atmosphere = RZ(L1U) + ZZHT (in cm)
 !     LTOP = L1U = top radius of CTM layers, LTOP+1 = top of atmosphere
 !-----------------------------------------------------------------------
-      implicit none
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
@@ -2677,7 +2661,6 @@
 !     LTOP = L1U = top radius of CTM layers, LTOP+1 = top of atmosphere
 !-----------------------------------------------------------------------
 
-      implicit none
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
@@ -2791,7 +2774,6 @@
 !        = 1/U0
 !-----------------------------------------------------------------------
 
-      implicit none
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
@@ -2843,7 +2825,6 @@
 !     JXTRA(L=1:L1x)  the number in levels to insert in each layer L
 !-----------------------------------------------------------------------
 
-      implicit none
       integer, intent(in) ::  L1X            !# layers
       integer, intent(in) ::  NX             !Mie scattering array size (max)
       real*8,  intent(in) ::  DTAU600(L1X)     !cloud+3aerosol OD in each layer
@@ -2903,7 +2884,6 @@
 !     SZA = solar zenith angle in degrees
 !     COSSZA = U0 = cos(SZA)
 !-----------------------------------------------------------------------
-      implicit none
 
       real*8,  intent(in)  ::  GMTIME,YGRDJ,XGRDI
       integer, intent(in)  ::  NDAY
@@ -2936,7 +2916,6 @@
 !---------------------------------------------------------------------
       subroutine  FJX_CLIRAD_H2O(nlayers, PPP, TTT, HHH, TAUG_CLIRAD)
 !---------------------------------------------------------------------
-      implicit none
 
       integer,  intent(in):: nlayers
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
@@ -3027,7 +3006,6 @@
 !---------------------------------------------------------------------
       subroutine  FJX_GGLLNL_H2O(nlayers, PPP, TTT, HHH, TAUG_LLNL)
 !---------------------------------------------------------------------
-      implicit none
 
       integer,  intent(in):: nlayers
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
@@ -3111,7 +3089,7 @@
 !-----------------------------------------------------------------------
 !  Load fast-JX climatology - T & O3 - for latitude & month & pressure grid
 !-----------------------------------------------------------------------
-      implicit none
+
       real*8,  intent(in)  :: YLATD
       integer, intent(in)  :: MONTH, L1U
       real*8,  intent(in),  dimension(L1U+1) :: PPP
@@ -3180,7 +3158,7 @@
 !  Calculates RH profile given PL(mid-pressure), TL(K), QL (spec hum)
 !  May nee RH @ L1U (top layer, not CTM) so aerosol calls are stable
 !-----------------------------------------------------------------------
-      implicit none
+
       integer, intent(in):: L1U
       real*8,  intent(in),  dimension(L1U) :: PL,TL,QL
       real*8,  intent(out), dimension(L1U) :: RH
@@ -3216,7 +3194,7 @@
 !-----------------------------------------------------------------------
 !---note that trigger for using GEOMIP aerosol properties is NAER(L) = 1001:1015
 !   numbers 1:nnn are reserved for standard ssa and trop aerosols.
-      implicit none
+
       real*8,  intent(in)  :: YLATD
       integer, intent(in)  :: MONTH, L1U
       real*8,  intent(in),  dimension(L1U+1) :: PPP

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -170,6 +170,7 @@
       logical, intent(out)                     :: LDARK  ! cloud-j output
 
 !-----------------------------------------------------------------------
+      character(len=255)  ::  thisloc
 !---key LOCAL atmospheric data needed to solve plane-parallel J & Heating
 !-----these are dimensioned L1_
       real*8, dimension(L1_+1) :: PPJ,ZZJ
@@ -214,12 +215,18 @@
 
 !-----------------------------------------------------------------------
 
+      ! Initialize location and outputs
+      thisloc = ' -> at PHOTO_JX in module cldj_fjx_sub_mod.F90'
+      VALJXX = 0.d0
+      SKPERD = 0.d0
+      SWMSQ  = 0.d0
+      OD18   = 0.d0
+      LDARK  = .FALSE.
+
       LU = L1U - 1
-      VALJXX(:,:) = 0.d0
-      FFXTAU(:,:) = 0.d0
-      SKPERD(:,:)=0.d0
-      SWMSQ(:)=0.d0
-      OD18(:)=0.d0
+      FFXTAU = 0.d0
+      SWMSQ = 0.d0
+      OD18 = 0.d0
 
 !---check for dark conditions SZA > 98.0 deg => tan ht = 63 km
 !                        or         99.0                 80 km
@@ -257,7 +264,7 @@
            AMG(L) = (1.d0 + ZMID/RAD)**2
         enddo
       else
-           AMG(:) = 1.d0
+           AMG = 1.d0
       endif
 
 !---calculate spherical weighting functions (AMF: Air Mass Factor)
@@ -273,9 +280,9 @@
       endif
 !-----------------------------------------------------------------------
 
-      TAUG_RRTMG(:,:)= 0.d0
-      TAUG_CLIRAD(:,:)=0.d0
-      TAUG_LLNL(:,:) = 0.d0
+      TAUG_RRTMG  = 0.d0
+      TAUG_CLIRAD = 0.d0
+      TAUG_LLNL   = 0.d0
 !SJ! needed in Solar-J version
 !      if (W_r .ne. 0)then
 !         if (W_r .eq. W_rrtmg)  call RRTMG_SW_INP(IYEAR,L1U,PPJ,ZZJ,DDJ,&
@@ -298,9 +305,9 @@
       endif
 
 ! >>>> major loop over standard levels:
-      OD(:,:) = 0.d0
-      SSA(:,:)= 0.d0
-      SLEG(:,:,:)=0.d0
+      OD   = 0.d0
+      SSA  = 0.d0
+      SLEG = 0.d0
       do L = 1,L1U
          OD600(L) = 0.d0
 ! initialize scattering/absoprtion data with Rayleigh scattering (always
@@ -572,18 +579,18 @@
               AVGF,FJTOP,FJBOT,FIBOT,FSBOT,FJFLX,FLXD,FLXD0, LDOKR,LU)
 
 !-----------------------------------------------------------------------
-      FFF(:,:) = 0.d0
+      FFF   = 0.d0
       FREFI = 0.d0
       FREFL = 0.d0
       FREFS = 0.d0
-      FLXUP(:) = 0.d0
-      DIRUP(:) = 0.d0
-      FLXDN(:) = 0.d0
-      DIRDN(:) = 0.d0
-      FLXJ(:) = 0.d0
-      FFX(:,:) = 0.d0
-      FFXNET(:,:) = 0.d0
-      FFXNETS(:) = 0.d0
+      FLXUP = 0.d0
+      DIRUP = 0.d0
+      FLXDN = 0.d0
+      DIRDN = 0.d0
+      FLXJ  = 0.d0
+      FFX   = 0.d0
+      FFXNET  = 0.d0
+      FFXNETS = 0.d0
       FREF1 = 0.d0
       FREF2 = 0.d0
       PREF1 = 0.d0
@@ -683,7 +690,7 @@
             FFXNETS(J) = FFXNETS(J) + FFXNET(K,J)*SOLF*FW(K)
          enddo
       enddo
-      SWMSQ(:) = 0.d0
+      SWMSQ = 0.d0
       do K=1,S_
          SWMSQ(1) = SWMSQ(1) + FFXNET(K,3)*SOLF*FW(K)
          SWMSQ(2) = SWMSQ(2) + FFXNET(K,4)*SOLF*FW(K)
@@ -748,7 +755,7 @@
             write(6,'(a5,20i8)')   ' bin:',(K, K=NW1,NW2)
             write(6,'(a5,20f8.1)') ' wvl:',(WL(K), K=NW1,NW2)
             write(6,'(a)') ' ---- 100000=Fsolar   MEAN INTENSITY per wvl bin'
-                 RATIO(:) = 0.d0
+                 RATIO = 0.d0
             do L = LU,1,-1
                do K=NW1,NW2
                   if (LDOKR(K) .gt. 0) then
@@ -867,7 +874,7 @@
       real*8, intent(out) ::  FJTOP(W_+W_r),FJBOT(W_+W_r),FSBOT(W_+W_r)
       real*8, intent(out) ::  FJFLX(L1_,W_+W_r),FLXD(L1_,W_+W_r),FLXD0(W_+W_r)
 
-      character(len=255)  ::  thisloc
+      character(len=255) ::  thisloc
       integer JADDTO,L2LEV(L1_+1)
       integer I,II,J,K,L,LL,LL0,IX,JK,   L2,L22,LZ,LZZ,ND
       integer L1U,  LZ0,LZ1,LZMID
@@ -956,7 +963,16 @@
 !     JADDTO is the cumulative number of JXTRA levels to be added
 !---these should be fixed for all wavelengths to lock-in the array sizes
 
+      ! initialize
       thisloc = ' -> at OPMIE in module cldj_fjx_sub_mod.F90'
+      FJACT = 0.d0
+      FJTOP = 0.d0
+      FIBOT = 0.d0
+      FJBOT = 0.d0
+      FSBOT = 0.d0
+      FJFLX = 0.d0
+      FLXD  = 0.d0
+      FLXD0 = 0.d0
 
       L1U = LU + 1   ! uppermost edge is LU+2
         JADDTO = 0  ! no added layers in the topmost added layer (goes to TAU=0)
@@ -976,17 +992,10 @@
 
 !----------------begin wavelength dependent set up------------------------------
 !---Reinitialize arrays
-        ZTAU(:,:)     = 0.d0
-        POMEGA(:,:,:) = 0.d0
-        FJACT(:,:) = 0.d0
-        FJTOP(:) = 0.d0
-        FJBOT(:) = 0.d0
-        FSBOT(:) = 0.d0
-        FJFLX(:,:) = 0.d0
-        FLXD(:,:) = 0.d0
-        FLXD0(:) = 0.d0
-        FJ(:,:) = 0.d0
-        FZ(:,:) = 0.d0
+        ZTAU   = 0.d0
+        POMEGA = 0.d0
+        FJ     = 0.d0
+        FZ     = 0.d0
 !---PRIMARY loop over wavelengths
       do K = 1,W_+W_r
       if (LDOKR(K) .gt. 0) then
@@ -1018,7 +1027,7 @@
              LL0 = LL
           endif
        enddo
-          FTAU(:) = 0.d0
+          FTAU = 0.d0
        do LL = LL0+1,L1U+1
 ! there is sunlight thru layer LL to layer edge/radius LL (=1:L1U)
 ! AMF(I,L) includes air mass effective (AMF ~ 1/U0) for all layers I at edge L
@@ -1287,7 +1296,12 @@
 !    ALSO limited to 4 Gauss points, only calculates mean field! (M=1)
 !-----------------------------------------------------------------------
 
-      thisloc = ' -> at MIESCT in module cldj_fjx_sub_mod.F90'
+      ! initialize location and outputs for safetly
+      thisloc  = ' -> at MIESCT in module cldj_fjx_sub_mod.F90'
+      FJ  = 0.d0
+      FJT = 0.d0
+      FJB = 0.d0
+      FIB = 0.d0
 
       do I = 1,M_
          call LEGND0 (EMU(I),PM0,M2_)
@@ -1323,7 +1337,9 @@
       integer I
       real*8  DEN
 
+      ! initialize location and output for safety
       thisloc = ' -> at LEGNDO in module cldj_fjx_sub_mod.F90'
+      PL = 0.d0
 
 !---Always does PL(2) = P[1]
       PL(1) = 1.d0
@@ -1361,7 +1377,12 @@
       real*8  SUMB,SUMBX,SUMT,SUMBR,SUMRF
       integer I, J, K, L
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at BLKSLV in module cldj_fjx_sub_mod.F90'
+      FJ    = 0.d0
+      FJTOP = 0.d0
+      FJBOT = 0.d0
+      FIBOT = 0.d0
 
       do K = 1,W_+W_r
       if (LDOKR(K) .gt. 0) then
@@ -1650,7 +1671,14 @@
       real*8, dimension(M_,M_) :: S,T,U,V,W
 !---------------------------------------------
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at GEN_ID in module cldj_fjx_sub_mod.F90'
+      B  = 0.d0
+      AA = 0.d0
+      CC = 0.d0
+      A  = 0.d0
+      C  = 0.d0
+      H  = 0.d0
 
 !---------upper boundary:  2nd-order terms
        L1 = 1
@@ -1910,11 +1938,16 @@
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
 
-      character(len=255) ::    thisloc
+      character(len=255) :: thisloc
       integer I,J,K,L, NR
       real*8  FNR
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at OPTICL in module cldj_fjx_sub_mod.F90'
+      DDENS = 0.d0
+      QQEXT = 0.d0
+      SSALB = 0.d0
+      SSLEG = 0.d0
 
       K = 1   ! liquid water Mie clouds
       DDENS = DCC(K)
@@ -1954,11 +1987,16 @@
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
 
-      character(len=255) ::    thisloc
+      character(len=255) :: thisloc
       integer I,J,K,L, NR
       real*8  FNR
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at OPTICI in module cldj_fjx_sub_mod.F90'
+      DDENS = 0.d0
+      QQEXT = 0.d0
+      SSALB = 0.d0
+      SSLEG = 0.d0
 
       if (TEFF .ge. 233.15d0) then
            K = 2  ! ice irreg (warm)
@@ -2008,7 +2046,11 @@
       integer I,J, KK
       real*8  XTINCT, REFF,RHO
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at OPTICS in module cldj_fjx_sub_mod.F90'
+      OPTD  = 0.d0
+      SSALB = 0.d0
+      SLEG  = 0.d0
 
       if (K .eq. 1) then
         KK = 4    ! background, 220K, 70 wt%
@@ -2048,11 +2090,15 @@
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
       real*8, intent(out)::    SLEG(8,S_)  ! scatt phase fn (Leg coeffs)
 
-      character(len=255)::     thisloc
+      character(len=255) :: thisloc
       integer I,J, KK
       real*8  XTINCT, REFF,RHO
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at OPTICG in module cldj_fjx_sub_mod.F90'
+      OPTD  = 0.d0
+      SSALB = 0.d0
+      SLEG  = 0.d0
 
       KK = max(1, min(NGG, K-1000))
       REFF = RGG(KK)
@@ -2085,11 +2131,15 @@
         character(len=255) ::    thisloc
         integer I,J,JMIE
         real*8  XTINCT, REFF,RHO,WAVE, QAAX,SAAX,WAAX
+
+        ! initialize location and outputs for safety
+        thisloc = ' -> at OPTICA in module cldj_fjx_sub_mod.F90'
+        OPTD  = 0.d0
+        SSALB = 0.d0
+        SLEG  = 0.d0
+
 ! K=1&2 are the SSA values, not used here any more, make sure they are not
 !asked for.
-
-        thisloc = ' -> at OPTICA in module cldj_fjx_sub_mod.F90'
-
         if (K.gt.NAA .or. K.lt.3) &
            call EXITC ('OPTICA: aerosol index out-of-range', thisloc)
         REFF = RAA(K)
@@ -2155,11 +2205,15 @@
       real*8, intent(in)::     RELH       ! relative humidity (0.00->1.00)
       integer,intent(in)::     LL         ! index of cloud/aerosols
 
-      character(len=255) ::    thisloc
+      character(len=255) :: thisloc
       integer KR,J,L, JMIE
       real*8  R,FRH, GCOS, XTINCT, WAVE
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at OPTICM in module cldj_fjx_sub_mod.F90'
+      OPTD  = 0.d0
+      SSALB = 0.d0
+      SLEG  = 0.d0
 
 !---calculate fast-JX properties at the std 5 wavelengths:200-300-400-600-999nm
 !---extrapolate phase fn from first term (g)
@@ -2214,13 +2268,15 @@
       real*8, intent(inout)  ::  FFF(W_,LU)
       real*8, intent(out), dimension(LU,NJXU) ::  VALJL
 
-      character(len=255) ::   thisloc
+      character(len=255) :: thisloc
       real*8  VALJ(X_)
       real*8  QO2TOT, QO3TOT, QO31DY, QO31D, QQQT, TFACT
       real*8  TT,PP,DD,TT200,TFACA,TFAC0,TFAC1,TFAC2,QQQA,QQ2,QQ1A,QQ1B
       integer J,K,L, IV
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at JRATET in module cldj_fjx_sub_mod.F90'
+      VALJL = 0.d0
 
       if (NJXU .lt. NJX) then
         write(6,'(A,2I5)')  'NJXU<NJX',NJXU,NJX
@@ -2297,7 +2353,9 @@
       character(len=255)::  thisloc
       real*8  TFACT
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at X_interp in module cldj_fjx_sub_mod.F90'
+      XINT = 0.d0
 
       if (L123 .le. 1) then
            XINT = X1
@@ -2334,6 +2392,7 @@
       integer  I,J,K,L
       real*8   XCOLO2,XCOLO3,ZKM,DELZ,ZTOP,DAIR,DOZO
 
+      ! initialize
       thisloc = ' -> at JP_ATM in module cldj_fjx_sub_mod.F90'
 
       write(6,'(4a)') '   L z(km)     p      T   ', &
@@ -2444,7 +2503,9 @@
       real*8, dimension(L1_+1,L1_+1) :: ZANG,ZAMF
       real*8, dimension(L1_+1) :: RZ,DIVZ,RATZ,RD,RN, PATH1,PATH2,ZANG1
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at SPHERE1R in module cldj_fjx_sub_mod.F90'
+      AMF = 0.d0
 
 !-----------------------------------------------------------------------
 !  this versions sets a density scale ht of DDHT=8km, and a
@@ -2471,11 +2532,10 @@
         CZA0 = U0
         ZA0 = acos(CZA0)
         SZA0 = sin(ZA0)
-      AMF(:,:) = 0.d0
       AMF(LTOP+1,LTOP+1) = 1.d0
 !-----------------------------------------------------------------------
-        ZAMF(:,:) = 0.d0
-        ZANG(:,:) = 0.d0
+        ZAMF = 0.d0
+        ZANG = 0.d0
 
       if (U0 .lt. 0.d0) goto 1111
 
@@ -2492,9 +2552,9 @@
 ! angle ZA0
          SA0 = SRN0/(RZ(LTOP+1)*RN(LTOP+1)) ! = sin of zenith angle at
 ! top of atmosphere
-         ZANG1(:) = 0.d0
+         ZANG1 = 0.d0
          ZANG1(LTOP+1) = asin(SA0)
-         PATH1(:) = 0.d0
+         PATH1 = 0.d0
        do K=LTOP,L,-1
 !  A1 = zenith angle at bottom layer K (from invariant)
          SA1 = SRN0/(RZ(K)*RN(K))
@@ -2514,7 +2574,7 @@
 ! angle ZA0
          SA0 = SRN0/(RZ(LTOP+1)*RN(LTOP+1)) ! A0 = zenith angle at top of
 ! atmosphere
-         PATH1(:) = 0.d0
+         PATH1 = 0.d0
        do K=LTOP,L,-1
 !  A1 = zenith angle at bottom layer K (from invariant)
          SA1 = SRN1/(RZ(K)*RN(K))
@@ -2541,9 +2601,9 @@
          SRN0 = RZ(L)*RN(L)    ! invariant path that hits tangent at RZ(L)
          SA0 = SRN0/(RZ(LTOP+1)*RN(LTOP+1)) ! = sin of zenith angle at top
 ! of atmosphere
-        ZANG1(:) = 0.d0
+        ZANG1 = 0.d0
         ZANG1(LTOP+1) = asin(SA0)
-        PATH1(:) = 0.d0
+        PATH1 = 0.d0
 ! begin going downward to tangent layer L (RZ(L) = lower layer edge of layer)
        do K=LTOP,L,-1
 !  A1 = zenith angle at bottom layer K (from invariant)
@@ -2591,7 +2651,7 @@
 ! at angle ZA0
           SA0 = SRN0/(RZ(LTOP+1)*RN(LTOP+1)) ! A0 = zenith angle at top of
 ! atmosphere
-          PATH1(:) = 0.d0
+          PATH1 = 0.d0
          do K=LTOP,L0,-1
 !  A1 = zenith angle at bottom layer K (from refracted invariant)
           SA1 = SRN1/(RZ(K)*RN(K))
@@ -2671,8 +2731,9 @@
 
       real*8, dimension(L1_+1) :: RZ,DIVZ,RATZ
 
-
+      ! initialize location and outputs for safety
       thisloc = ' -> at SPHERE1N in module cldj_fjx_sub_mod.F90'
+      AMF = 0.d0
 
       LTOP = L1U
       do L = 1,LTOP
@@ -2687,7 +2748,6 @@
         A0 = acos(CA0)
         SA0 = sin(A0)
         R0 = RZ(1)
-      AMF(:,:) = 0.d0
       AMF(LTOP+1,LTOP+1) = 1.d0
 !-----------------------------------------------------------------------
 
@@ -2782,10 +2842,11 @@
       integer  L, J, LTOP
       real*8   PATH0
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at SPHERE1F in module cldj_fjx_sub_mod.F90'
+      AMF = 0.d0
 
       LTOP = L1U
-      AMF(:,:) = 0.d0
       AMF(LTOP+1,LTOP+1) = 1.d0
 
       if (U0 .gt. 0.d0) then
@@ -2834,7 +2895,9 @@
       integer JTOTL,JX,L,LL
       real*8  ATAULN,ATAU0X,AJX,DTAU0X
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at EXTRAL1 in module cldj_fjx_sub_mod.F90'
+      JXTRA = 0
 
 !  need to divide DTAU600 into JX layers such that DTAU600/ATAU0 = ratio =
 !       1 + ATAU + ATAU^2 + ATAU^3 + ATAU^(JX-1)  = [ATAU^JX - 1]/[ATAU - 1]
@@ -2892,7 +2955,7 @@
       character(len=255)   ::  thisloc
       real*8  LOCT
       real*8  SINDEC, SOLDEK, COSDEC, SINLAT, SOLLAT, COSLAT, COSZ
-!
+
       thisloc = ' -> at SOLAR_JX in module cldj_fjx_sub_mod.F90'
 
       SINDEC = 0.3978d0*sin(0.9863d0*(dble(NDAY)-80.d0)*CPI180)
@@ -2903,9 +2966,10 @@
       COSLAT = cos(SOLLAT)
 !
       LOCT   = (((GMTIME)*15.d0)-180.d0)*CPI180 + XGRDI
+
+      ! set outputs
       COSSZA = COSDEC*COSLAT*cos(LOCT) + SINDEC*SINLAT
       SZA    = acos(COSSZA)/CPI180
-!
       SOLFX  = 1.d0-(0.034d0*cos(dble(NDAY-186)*C2PI/365.d0))
 !
       END SUBROUTINE SOLAR_JX
@@ -2967,10 +3031,11 @@
       real*8, parameter :: CMF = 2.98897027277D-23 ! 18.d0 divided by
 ! Avogado number
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at FJX_CLIRAD_H2O in module cldj_fjx_sub_mod.F90'
+      TAUG_CLIRAD = 0.d0
 
 ! 0:0 will assign to bin 18 which is 0 for CLIRAD
-      TAUG_CLIRAD(:,0:0)= 0.d0
       do L=1, nlayers
          pavg= 0.5d0* (PPP(L)+PPP(L+1))
 ! Weighting function Pr=300 hPa, Tr=240K;
@@ -3045,10 +3110,11 @@
 
       real*8, parameter :: CMF = 2.98897027277D-23 ! 18.d0 divided by Avogado number
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at FJX_GGLLNL_H2O in module cldj_fjx_sub_mod.F90'
+      TAUG_LLNL = 0.d0
 
-! 0:0 will assign to bin 18 which is 0 for CLIRAD
-      TAUG_LLNL(:,0)= 0.d0
+      ! 0:0 will assign to bin 18 which is 0 for CLIRAD
       do L=1, nlayers
          pavg= 0.5d0* (PPP(L)+PPP(L+1))
 ! Weighting function Pr=300 hPa, Tr=240K;
@@ -3100,7 +3166,11 @@
       integer  K, L, M, N
       real*8   DDDL,DLOGP,F0,T0,H0,C0,PB,PC,XC
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_FJX in module cldj_fjx_sub_mod.F90'
+      TTT = 0.d0
+      O3  = 0.d0
+      CH4 = 0.d0
 
 !  Select appropriate month
       M = max(1,min(12,MONTH))
@@ -3167,7 +3237,9 @@
       real*8  T, eps, es, qs
       integer  L
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_RH in module cldj_fjx_sub_mod.F90'
+      RH = 0.d0
 
       eps=287.04d0/461.50d0
       do L = 1,L1U-1
@@ -3207,7 +3279,10 @@
       integer  I, IGG, K, L, M, N
       real*8   R0,X0,RX0,PB,PC,XC,YN,REDGE(GGA_)
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_GEO in module cldj_fjx_sub_mod.F90'
+      AERS = 0.d0
+      NAER = 0
 
 !  Select appropriate month
       M = max(1, min(12, MONTH))
@@ -3220,8 +3295,8 @@
       enddo
       N = max(1, min(64, N))
 !---P_GREF = 2.7,.... 339 hPa (reverse order) ensure ZERO ssa above and below
-      RREF2(:) = 0.d0
-      XREF2(:) = 0.d0
+      RREF2 = 0.d0
+      XREF2 = 0.d0
       do K = 1,LGREF
          PREF2(K+1) = P_GREF(LGREF+1-K)
          RREF2(K+1) = R_GREF(N,LGREF+1-K,M)

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -869,6 +869,7 @@
       real*8, intent(out) ::  FJTOP(W_+W_r),FJBOT(W_+W_r),FSBOT(W_+W_r)
       real*8, intent(out) ::  FJFLX(L1_,W_+W_r),FLXD(L1_,W_+W_r),FLXD0(W_+W_r)
 
+      character(len=255)  ::  thisloc
       integer JADDTO,L2LEV(L1_+1)
       integer I,II,J,K,L,LL,LL0,IX,JK,   L2,L22,LZ,LZZ,ND
       integer L1U,  LZ0,LZ1,LZMID
@@ -957,6 +958,8 @@
 !     JADDTO is the cumulative number of JXTRA levels to be added
 !---these should be fixed for all wavelengths to lock-in the array sizes
 
+      thisloc = ' -> at OPMIE in module cldj_fjx_sub_mod.F90'
+
       L1U = LU + 1   ! uppermost edge is LU+2
         JADDTO = 0  ! no added layers in the topmost added layer (goes to TAU=0)
       do L = 1,L1U
@@ -964,7 +967,7 @@
       enddo
       ND = 2*L1U + 2*JADDTO + 1
       if(ND .gt. N_) then
-        call EXITC (' overflow of scatter arrays: ND > N_')
+        call EXITC (' overflow of scatter arrays: ND > N_', thisloc)
       endif
 !---L2LEV(L) = L-index for old layer-edge L in the expanded JXTRA-grid
 !     in absence of JXTRA,  L2LEV(L) = L
@@ -1262,11 +1265,13 @@
       subroutine MIESCT(FJ,FJT,FJB,FIB, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND)
 !-----------------------------------------------------------------------
       implicit none
+
       integer, intent(in)  ::  LDOKR(W_+W_r),ND
       real*8,  intent(in)  ::  POMEGA(M2_,N_,W_+W_r),FZ(N_,W_+W_r), &
                                ZTAU(N_,W_+W_r),RFL(5,W_+W_r),U0,FSBOT(W_+W_r)
       real*8,  intent(out) ::  FJ(N_,W_+W_r),FJT(W_+W_r)
       real*8,  intent(out) ::  FJB(W_+W_r),FIB(5,W_+W_r)
+      character(len=255)   ::  thisloc
       real*8  PM(M_,M2_),PM0(M2_)
       integer I, IM  ,K
 !-----------------------------------------------------------------------
@@ -1284,6 +1289,9 @@
 !    takes atmospheric structure and source terms from std J-code
 !    ALSO limited to 4 Gauss points, only calculates mean field! (M=1)
 !-----------------------------------------------------------------------
+
+      thisloc = ' -> at MIESCT in module cldj_fjx_sub_mod.F90'
+
       do I = 1,M_
          call LEGND0 (EMU(I),PM0,M2_)
          do IM = 1,M2_
@@ -1314,8 +1322,12 @@
       integer, intent(in) :: N
       real*8, intent(in)  :: X
       real*8, intent(out) :: PL(N)
+      character(len=255)  :: thisloc
       integer I
       real*8  DEN
+
+      thisloc = ' -> at LEGNDO in module cldj_fjx_sub_mod.F90'
+
 !---Always does PL(2) = P[1]
       PL(1) = 1.d0
       PL(2) = X
@@ -1345,12 +1357,15 @@
       real*8, intent(out) ::  FJ(N_,W_+W_r),FJTOP(W_+W_r),FJBOT(W_+W_r), &
                               FIBOT(5,W_+W_r)
 
+      character(len=255)  ::  thisloc
       real*8, dimension(M_,N_,W_+W_r)    ::  A,C,H,   RR
 
       real*8, dimension(M_,M_,N_,W_+W_r) ::  B,AA,CC,  DD
       real*8, dimension(M_,M_) ::  E
       real*8  SUMB,SUMBX,SUMT,SUMBR,SUMRF
       integer I, J, K, L
+
+      thisloc = ' -> at BLKSLV in module cldj_fjx_sub_mod.F90'
 
       do K = 1,W_+W_r
       if (LDOKR(K) .gt. 0) then
@@ -1632,12 +1647,15 @@
       real*8, intent(out),dimension(M_,M_,N_) ::  B,AA,CC
       real*8, intent(out),dimension(M_,N_) ::  A,C,H
 
+      character(len=255)  ::  thisloc
       integer I, J, K, L1,L2,LL
       real*8  SUM0, SUM1, SUM2, SUM3
       real*8  DELTAU, D1, D2, SURFAC,SUMRFL
 !
       real*8, dimension(M_,M_) :: S,T,U,V,W
 !---------------------------------------------
+
+      thisloc = ' -> at GEN_ID in module cldj_fjx_sub_mod.F90'
 
 !---------upper boundary:  2nd-order terms
        L1 = 1
@@ -1899,8 +1917,11 @@
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
 
+      character(len=255) ::    thisloc
       integer I,J,K,L, NR
       real*8  FNR
+
+      thisloc = ' -> at OPTICL in module cldj_fjx_sub_mod.F90'
 
       K = 1   ! liquid water Mie clouds
       DDENS = DCC(K)
@@ -1942,10 +1963,13 @@
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
 
+      character(len=255) ::    thisloc
       integer I,J,K,L, NR
       real*8  FNR
 
-        if (TEFF .ge. 233.15d0) then
+      thisloc = ' -> at OPTICI in module cldj_fjx_sub_mod.F90'
+
+      if (TEFF .ge. 233.15d0) then
            K = 2  ! ice irreg (warm)
         else
            K = 3  ! ice hexag (cold)
@@ -1991,15 +2015,18 @@
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
       real*8, intent(out)::    SLEG(8,S_) ! scatt phase fn (Leg coeffs)
 
+      character(len=255)::     thisloc
       integer I,J, KK
       real*8  XTINCT, REFF,RHO
+
+      thisloc = ' -> at OPTICS in module cldj_fjx_sub_mod.F90'
 
       if (K .eq. 1) then
         KK = 4    ! background, 220K, 70 wt%
       elseif (K .eq. 2) then
         KK = 13   ! volcanic,   220K, 70 wt%
       else
-        call EXITC ('OPTICS: SSA index out-of-range')
+        call EXITC ('OPTICS: SSA index out-of-range', thisloc)
       endif
 
          REFF = RSS(KK)
@@ -2033,8 +2060,11 @@
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
       real*8, intent(out)::    SLEG(8,S_)  ! scatt phase fn (Leg coeffs)
 
+      character(len=255)::     thisloc
       integer I,J, KK
       real*8  XTINCT, REFF,RHO
+
+      thisloc = ' -> at OPTICG in module cldj_fjx_sub_mod.F90'
 
       KK = max(1, min(NGG, K-1000))
       REFF = RGG(KK)
@@ -2064,12 +2094,16 @@
         real*8, intent(in)::     PATH        ! path (g/m2) of aerosol/cloud
         real*8, intent(in)::     RELH        ! relative humidity (0.00->1.00+)
         integer,intent(inout)::     K        ! index of cloud/aerosols
+        character(len=255) ::    thisloc
         integer I,J,JMIE
         real*8  XTINCT, REFF,RHO,WAVE, QAAX,SAAX,WAAX
 ! K=1&2 are the SSA values, not used here any more, make sure they are not
 !asked for.
+
+        thisloc = ' -> at OPTICA in module cldj_fjx_sub_mod.F90'
+
         if (K.gt.NAA .or. K.lt.3) &
-           call EXITC ('OPTICA: aerosol index out-of-range')
+           call EXITC ('OPTICA: aerosol index out-of-range', thisloc)
         REFF = RAA(K)
         RHO = DAA(K)
         do J = 1,S_
@@ -2134,14 +2168,17 @@
       real*8, intent(in)::     RELH       ! relative humidity (0.00->1.00)
       integer,intent(in)::     LL         ! index of cloud/aerosols
 
+      character(len=255) ::    thisloc
       integer KR,J,L, JMIE
       real*8  R,FRH, GCOS, XTINCT, WAVE
+
+      thisloc = ' -> at OPTICM in module cldj_fjx_sub_mod.F90'
 
 !---calculate fast-JX properties at the std 5 wavelengths:200-300-400-600-999nm
 !---extrapolate phase fn from first term (g)
       L = LL
       if (L.lt.1 .or. L.gt.33)  &
-          call EXITC ('OPTICM: aerosol index out-of-range')
+          call EXITC ('OPTICM: aerosol index out-of-range', thisloc)
 !---pick nearest Relative Humidity
       KR =  20.d0*RELH  + 1.5d0
       KR = max(1, min(21, KR))
@@ -2191,14 +2228,17 @@
       real*8, intent(inout)  ::  FFF(W_,LU)
       real*8, intent(out), dimension(LU,NJXU) ::  VALJL
 
+      character(len=255) ::   thisloc
       real*8  VALJ(X_)
       real*8  QO2TOT, QO3TOT, QO31DY, QO31D, QQQT, TFACT
       real*8  TT,PP,DD,TT200,TFACA,TFAC0,TFAC1,TFAC2,QQQA,QQ2,QQ1A,QQ1B
       integer J,K,L, IV
 
+      thisloc = ' -> at JRATET in module cldj_fjx_sub_mod.F90'
+
       if (NJXU .lt. NJX) then
         write(6,'(A,2I5)')  'NJXU<NJX',NJXU,NJX
-        call EXITC(' JRATET:  CTM has not enough J-values dimensioned')
+        call EXITC(' JRATET:  CTM has not enough J-values dimensioned', thisloc)
       endif
 
       do L = 1,LU
@@ -2269,7 +2309,10 @@
       integer,intent(in)::  L123
       real*8, intent(out)::  XINT
 
+      character(len=255)::  thisloc
       real*8  TFACT
+
+      thisloc = ' -> at X_interp in module cldj_fjx_sub_mod.F90'
 
       if (L123 .le. 1) then
            XINT = X1
@@ -2302,8 +2345,11 @@
       real*8, intent(in), dimension(8,LU+1) :: POMEG6
       integer,intent(in), dimension(LU+1) :: JXTRA
 !-----------------------------------------------------------------------
+      character(len=255)  ::  thisloc
       integer  I,J,K,L
       real*8   XCOLO2,XCOLO3,ZKM,DELZ,ZTOP,DAIR,DOZO
+
+      thisloc = ' -> at JP_ATM in module cldj_fjx_sub_mod.F90'
 
       write(6,'(4a)') '   L z(km)     p      T   ', &
        '    d(air)   d(O3)','  col(O2)  col(O3)     d-TAU   SS-alb', &
@@ -2342,8 +2388,12 @@
       real*8, intent(in), dimension(LU+2) :: PPJ,ZZJ
       real*8, intent(in), dimension(LU+1) :: TTJ,DDJ,OOJ
 !-----------------------------------------------------------------------
+      character(len=255)  ::  thisloc
       integer  I,J,K,L
       real*8   XCOLO2,XCOLO3,ZKM,DELZ,ZTOP
+
+      thisloc = ' -> at JP_ATM0 in module cldj_fjx_sub_mod.F90'
+
       write(6,'(4a)') '   L z(km)     p      T   ', &
        '    d(air)   d(O3)','  col(O2)  col(O3)     d-TAU   SS-alb', &
        '  g(cos) CTM lyr=>'
@@ -2402,12 +2452,16 @@
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
 
+      character(len=255)  ::   thisloc
       integer  L,L0, K,K0, LTOP
       real*8   ZA0,SZA0,CZA0
       real*8   ZA1,SZA1,SRN0,SA0,A0,CA0,SRN1,SA1,A1,CA1,SA2,A2,CA2
       real*8   DDHT,REF0,F0, C90
       real*8, dimension(L1_+1,L1_+1) :: ZANG,ZAMF
       real*8, dimension(L1_+1) :: RZ,DIVZ,RATZ,RD,RN, PATH1,PATH2,ZANG1
+
+      thisloc = ' -> at SPHERE1R in module cldj_fjx_sub_mod.F90'
+
 !-----------------------------------------------------------------------
 !  this versions sets a density scale ht of DDHT=8km, and a
 !        refractive index of 1.000300 at radius = RAD,
@@ -2628,10 +2682,14 @@
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
 
+      character(len=255)  ::   thisloc
       integer  L, J, JUP, LTOP, K
       real*8   A0,A1,A2,SA0,SA1,SA2,CA0,CA1,CA2,R0, PATH,ZA0,CZA0,SZA0
 
       real*8, dimension(L1_+1) :: RZ,DIVZ,RATZ
+
+
+      thisloc = ' -> at SPHERE1N in module cldj_fjx_sub_mod.F90'
 
       LTOP = L1U
       do L = 1,LTOP
@@ -2738,8 +2796,11 @@
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
 
+      character(len=255)  ::   thisloc
       integer  L, J, LTOP
       real*8   PATH0
+
+      thisloc = ' -> at SPHERE1F in module cldj_fjx_sub_mod.F90'
 
       LTOP = L1U
       AMF(:,:) = 0.d0
@@ -2788,8 +2849,11 @@
       real*8,  intent(in) ::  DTAU600(L1X)     !cloud+3aerosol OD in each layer
       real*8,  intent(in) ::  ATAU,ATAU0
       integer, intent(out)::  JXTRA(L1X)    !number of sub-layers to be added
+      character(len=255)  ::  thisloc
       integer JTOTL,JX,L,LL
       real*8  ATAULN,ATAU0X,AJX,DTAU0X
+
+      thisloc = ' -> at EXTRAL1 in module cldj_fjx_sub_mod.F90'
 
 !  need to divide DTAU600 into JX layers such that DTAU600/ATAU0 = ratio =
 !       1 + ATAU + ATAU^2 + ATAU^3 + ATAU^(JX-1)  = [ATAU^JX - 1]/[ATAU - 1]
@@ -2817,7 +2881,7 @@
             do LL = L,1,-1
                JXTRA(LL) = 0
             enddo
-!           call exitc('STOP at EXTRAL') !not necessary, a warning is OK
+!           call exitc('STOP at EXTRAL', thisloc) !not necessary, a warning is OK
             go to 10
          endif
       enddo
@@ -2845,9 +2909,12 @@
       integer, intent(in)  ::  NDAY
       real*8,  intent(out) ::  SZA,COSSZA,SOLFX
 !
+      character(len=255)   ::  thisloc
       real*8  LOCT
       real*8  SINDEC, SOLDEK, COSDEC, SINLAT, SOLLAT, COSLAT, COSZ
 !
+      thisloc = ' -> at SOLAR_JX in module cldj_fjx_sub_mod.F90'
+
       SINDEC = 0.3978d0*sin(0.9863d0*(dble(NDAY)-80.d0)*CPI180)
       SOLDEK = asin(SINDEC)
       COSDEC = cos(SOLDEK)
@@ -2875,6 +2942,7 @@
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
       real*8 ,  intent(out):: TAUG_CLIRAD(nlayers, 0:30)
 
+      character(len=255)  :: thisloc
       integer G, K, INDKG, L
       real*8, dimension(nlayers):: WT
 ! heating rate (K/day) = W/m2 deposited in layer * HeatFac_ / delta-P of
@@ -2918,7 +2986,9 @@
        0.0010, 0.0032, 0.0102, 0.0328, 0.1049, 0.4194, 2.5166, 17.616, &
        123.31, 839.19]
       real*8, parameter :: CMF = 2.98897027277D-23 ! 18.d0 divided by
-! Avagado number
+! Avogado number
+
+      thisloc = ' -> at FJX_CLIRAD_H2O in module cldj_fjx_sub_mod.F90'
 
 ! 0:0 will assign to bin 18 which is 0 for CLIRAD
       TAUG_CLIRAD(:,0:0)= 0.d0
@@ -2963,6 +3033,7 @@
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
       real*8 ,  intent(out):: TAUG_LLNL(nlayers, 0:21)
 
+      character(len=255)  :: thisloc
       integer G, K, INDKG, L
       real*8, dimension(nlayers):: WT
 ! heating rate (K/day) = W/m2 deposited in layer * HeatFac_ / delta-P of
@@ -2994,8 +3065,9 @@
            1.8492E+02, 1.6292E+03 /), &
         SHAPE = (/ 7, 3 /) )
 
-      real*8, parameter :: CMF = 2.98897027277D-23 ! 18.d0 divided by
-!Avagado number
+      real*8, parameter :: CMF = 2.98897027277D-23 ! 18.d0 divided by Avogado number
+
+      thisloc = ' -> at FJX_GGLLNL_H2O in module cldj_fjx_sub_mod.F90'
 
 ! 0:0 will assign to bin 18 which is 0 for CLIRAD
       TAUG_LLNL(:,0)= 0.d0
@@ -3046,8 +3118,12 @@
       real*8,  intent(out), dimension(L1U)   :: TTT,O3,CH4
       real*8, dimension(LREF)   :: OREF2,TREF2,HREF2,CREF2
       real*8, dimension(LREF+1) :: PSTD
+      character(len=255)  ::  thisloc
       integer  K, L, M, N
       real*8   DDDL,DLOGP,F0,T0,H0,C0,PB,PC,XC
+
+      thisloc = ' -> at ACLIM_FJX in module cldj_fjx_sub_mod.F90'
+
 !  Select appropriate month
       M = max(1,min(12,MONTH))
 !  Select appropriate latitudinal profiles
@@ -3109,8 +3185,11 @@
       real*8,  intent(in),  dimension(L1U) :: PL,TL,QL
       real*8,  intent(out), dimension(L1U) :: RH
 ! local variables
+      character(len=255)  ::  thisloc
       real*8  T, eps, es, qs
       integer  L
+
+      thisloc = ' -> at ACLIM_RH in module cldj_fjx_sub_mod.F90'
 
       eps=287.04d0/461.50d0
       do L = 1,L1U-1
@@ -3144,10 +3223,13 @@
       real*8,  intent(out), dimension(L1U)   :: AERS
       integer, intent(out), dimension(L1U)   :: NAER
 
+      character(len=255)  ::  thisloc
       real*8, dimension(LGREF+2) :: RREF2,XREF2,PREF2    ! param LGREF=19
       real*8, dimension(LGREF+3) :: PSTD2
       integer  I, IGG, K, L, M, N
       real*8   R0,X0,RX0,PB,PC,XC,YN,REDGE(GGA_)
+
+      thisloc = ' -> at ACLIM_GEO in module cldj_fjx_sub_mod.F90'
 
 !  Select appropriate month
       M = max(1, min(12, MONTH))
@@ -3217,11 +3299,12 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine EXITC(T_EXIT)
+      subroutine EXITC(T_EXIT, LOC)
 !-----------------------------------------------------------------------
-      character(len=*), intent(in) ::  T_EXIT
+        character(len=*), intent(in) ::  T_EXIT
+        character(len=*), intent(in) ::  LOC
 
-      call cloudj_error_stop(T_EXIT)
+      call cloudj_error_stop(T_EXIT, LOC)
 
       END SUBROUTINE EXITC
 

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -131,7 +131,7 @@
 !-----------------------------------------------------------------------
       subroutine PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ, PPP,ZZZ,TTT,HHH,    &
                        DDD,RRR,OOO, CCC, LWP,IWP,REFFL,REFFI,AERSP,    &
-                       NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK)
+                       NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK,RC)
 !  PHOTO_JX is the gateway to fast-JX calculations:
 !    calc J's for a single column atmosphere (aka Indep Colm Atmos or ICA)
 !    needs P, T, O3, clds, aersls; adds top-of-atmos layer from climatology
@@ -167,6 +167,7 @@
       real*8,  intent(out), dimension(6)       :: SWMSQ  ! cloud-j output
       real*8,  intent(out), dimension(L1U)     :: OD18   ! cloud-j output
       logical, intent(out)                     :: LDARK  ! cloud-j output
+      integer, intent(out)                     :: RC     ! cloud-j output
 
 !-----------------------------------------------------------------------
       character(len=255)  ::  thisloc
@@ -216,6 +217,7 @@
 
       ! Initialize location and outputs
       thisloc = ' -> at PHOTO_JX in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       VALJXX = 0.d0
       SKPERD = 0.d0
       SWMSQ  = 0.d0
@@ -270,12 +272,12 @@
 !   indep of wavelength (refracted path assumes visible index of refraction)
 !-----------------------------------------------------------------------
       if (ATM0 .eq. 0) then
-         call SPHERE1F (U0,RAD,ZZJ,ZZHT,AMF, L1U)  ! flat Earth, AMF=1/u0
+         call SPHERE1F (U0,RAD,ZZJ,ZZHT,AMF, L1U,RC)  ! flat Earth, AMF=1/u0
       elseif (ATM0 .eq. 1) then
-         call SPHERE1N (U0,RAD,ZZJ,ZZHT,AMF, L1U)  ! spherical straight-line
+         call SPHERE1N (U0,RAD,ZZJ,ZZHT,AMF, L1U,RC)  ! spherical straight-line
                                                    ! paths
       else     ! 2 or 3
-         call SPHERE1R (U0,RAD,ZZJ,ZZHT,AMF, L1U)  ! spherical w/refraction
+         call SPHERE1R (U0,RAD,ZZJ,ZZHT,AMF, L1U,RC)  ! spherical w/refraction
       endif
 !-----------------------------------------------------------------------
 
@@ -285,10 +287,10 @@
 !SJ! needed in Solar-J version
 !      if (W_r .ne. 0)then
 !         if (W_r .eq. W_rrtmg)  call RRTMG_SW_INP(IYEAR,L1U,PPJ,ZZJ,DDJ,&
-!                                                  TTJ,HHJ,OOJ,CCJ,TAUG_RRTMG)
+!                                                  TTJ,HHJ,OOJ,CCJ,TAUG_RRTMG,RC)
 !         if (W_r .eq. W_Clirad) call FJX_CLIRAD_H2O(L1U,PPJ,TTJ,HHJ,&
-!                                                    TAUG_CLIRAD)
-!         if (W_r .eq. W_LLNL)   call FJX_GGLLNL_H2O(L1U,PPJ,TTJ,HHJ,TAUG_LLNL)
+!                                                    TAUG_CLIRAD,RC)
+!         if (W_r .eq. W_LLNL)   call FJX_GGLLNL_H2O(L1U,PPJ,TTJ,HHJ,TAUG_LLNL,RC)
 !         write(6,'(a,I5,a,I5,a,I5,a,I5)')'W_r=    ', W_r, 'W_rrtmg=', &
 !               W_rrtmg, 'W_clirad=', W_clirad, 'W_LLNL=', W_LLNL
 
@@ -333,7 +335,7 @@
             RE_LIQ = REFFL(L)
             TE_ICE = TTT(L)
 
-            call OPTICL (RE_LIQ,TE_ICE, DDENS, QQEXT,SSALB,SSLEG)
+            call OPTICL (RE_LIQ,TE_ICE, DDENS, QQEXT,SSALB,SSLEG,RC)
 !---extinction K(m2/g) = 3/4 * Q / [Reff(micron) * density(g/cm3)]
             do K = 1,S_
                ODL = LWP(L) * 0.75d0 * QQEXT(K) / (RE_LIQ * DDENS)
@@ -360,7 +362,7 @@
             RE_ICE = REFFI(L)
             TE_ICE = TTT(L)
 
-            call OPTICI (RE_ICE,TE_ICE, DDENS, QQEXT,SSALB,SSLEG)
+            call OPTICI (RE_ICE,TE_ICE, DDENS, QQEXT,SSALB,SSLEG,RC)
 !---extinction K(m2/g) = 3/4 * Q / [Reff(micron) * density(g/cm3)]
             do K = 1,S_
                ODL = IWP(L) * 0.75d0 * QQEXT(K) / (RE_ICE * DDENS)
@@ -391,7 +393,7 @@
                PATH = AERSP(L,M)
                if (PATH .gt. 0.d0) then
 
-                  call OPTICS (OPTX,SSALB,SSLEG, PATH,NAER)
+                  call OPTICS (OPTX,SSALB,SSLEG, PATH,NAER,RC)
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
                      SSA(K,L) = SSA(K,L) + SSALB(K)*OPTX(K)
@@ -417,7 +419,7 @@
                PATH = AERSP(L,M)
                if (PATH .gt. 0.d0) then
 
-                  call OPTICG (OPTX,SSALB,SSLEG, PATH,NAER)
+                  call OPTICG (OPTX,SSALB,SSLEG, PATH,NAER,RC)
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
                      SSA(K,L) = SSA(K,L) + SSALB(K)*OPTX(K)
@@ -446,7 +448,7 @@
             PATH = AERSP(L,M)
             if (PATH .gt. 0.d0) then
                if (NAER.gt.2 .and. NAER.lt.1000) then
-                  call OPTICA (OPTX,SSALB,SSLEG, PATH,RH, NAER)
+                  call OPTICA (OPTX,SSALB,SSLEG, PATH,RH, NAER,RC)
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
                      SSA(K,L) = SSA(K,L) + SSALB(K)*OPTX(K)
@@ -470,7 +472,7 @@
             if (PATH .gt. 0.d0) then
                if (NAER .lt. 0) then
 
-                  call OPTICM (OPTX,SSALB,SSLEG, PATH,RH, -NAER)
+                  call OPTICM (OPTX,SSALB,SSLEG, PATH,RH, -NAER,RC)
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
                      SSA(K,L) = SSA(K,L) + SSALB(K)*OPTX(K)
@@ -493,9 +495,9 @@
          do K = 1,W_
             TTTX = TTJ(L)
             call X_interp (TTTX,XQO2, TQQ(1,1),QO2(K,1), TQQ(2,1), &
-                           QO2(K,2),  TQQ(3,1),QO2(K,3), LQQ(1))
+                           QO2(K,2),  TQQ(3,1),QO2(K,3), LQQ(1), RC)
             call X_interp (TTTX,XQO3, TQQ(1,2),QO3(K,1), TQQ(2,2), &
-                           QO3(K,2),  TQQ(3,2),QO3(K,3), LQQ(2))
+                           QO3(K,2),  TQQ(3,2),QO3(K,3), LQQ(2), RC)
             ODABS = XQO3*OOJ(L) + XQO2*DDJ(L)*0.20948d0
             OD(K,L)  = OD(K,L)  + ODABS
 !SJ!       if (LPRTJ) then
@@ -569,13 +571,13 @@
 
 !---Using aerosol+cloud OD/layer in visible (600 nm) calculate how to add layers
 !-----------------------------------------------------------------------
-      call EXTRAL1(OD600,L1U,N_,ATAU,ATAU0, JXTRA)
+      call EXTRAL1(OD600,L1U,N_,ATAU,ATAU0, JXTRA, RC)
 !-----------------------------------------------------------------------
 !---complete calculation of actinic and net fluxes for all L & wavelengths
 ! (incl W_+W_r)
 !-----------------------------------------------------------------------
       call OPMIE (DTAUX,POMEGAX,U0,RFL,AMF,AMG,JXTRA, &
-              AVGF,FJTOP,FJBOT,FIBOT,FSBOT,FJFLX,FLXD,FLXD0, LDOKR,LU)
+              AVGF,FJTOP,FJBOT,FIBOT,FSBOT,FJFLX,FLXD,FLXD0, LDOKR,LU,RC)
 
 !-----------------------------------------------------------------------
       FFF   = 0.d0
@@ -613,7 +615,7 @@
 !done in main code
 
 !-----------------------------------------------------------------------
-      call JRATET(PPJ,TTJ,FFF, VALJXX, LU,NJXU)
+      call JRATET(PPJ,TTJ,FFF, VALJXX, LU,NJXU,RC)
 !-----------------------------------------------------------------------
 
 ! accumulate data on solar fluxes:  energy and solar heating (!:S_),
@@ -711,7 +713,7 @@
             enddo
          enddo
          write(6,'(a)') 'Fast-J  v7.6 ---PHOTO_JX internal print: Atmosphere--'
-         call JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU600,POMG600,JXTRA, LU)
+         call JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU600,POMG600,JXTRA, LU,RC)
 !SJ!         if (LRRTMG .or. LCLIRAD .or. LGGLLNL) then
 !SJ!            write(ParaSummary(26:200),'(a, 10f10.4)') &
 !SJ!               ' RFL(,18)/SZA/u0/maxOD600/F-incd/F-refl/: ', &
@@ -862,7 +864,7 @@
 !<<<<<<<<<<<<<<<<<<<<<<<begin core scattering subroutines<<<<<<<<<<<<<<<
 !-----------------------------------------------------------------------
       subroutine OPMIE (DTAUX,POMEGAX,U0,RFL,AMF,AMG,JXTRA, &
-              FJACT,FJTOP,FJBOT,FIBOT,FSBOT,FJFLX,FLXD,FLXD0, LDOKR,LU)
+              FJACT,FJTOP,FJBOT,FIBOT,FSBOT,FJFLX,FLXD,FLXD0, LDOKR,LU,RC)
 !-----------------------------------------------------------------------
 
       real*8, intent(in)  ::  DTAUX(L1_,W_+W_r),POMEGAX(M2_,L1_,W_+W_r)
@@ -872,11 +874,12 @@
       real*8, intent(out) ::  FJACT(L1_,W_+W_r),FIBOT(5,W_+W_r)
       real*8, intent(out) ::  FJTOP(W_+W_r),FJBOT(W_+W_r),FSBOT(W_+W_r)
       real*8, intent(out) ::  FJFLX(L1_,W_+W_r),FLXD(L1_,W_+W_r),FLXD0(W_+W_r)
+      integer, intent(out) :: RC
 
       character(len=255) ::  thisloc
       integer JADDTO,L2LEV(L1_+1)
       integer I,II,J,K,L,LL,LL0,IX,JK,   L2,L22,LZ,LZZ,ND
-      integer L1U,  LZ0,LZ1,LZMID, rc
+      integer L1U,  LZ0,LZ1,LZMID
       real*8   SUMT,SUMJ,DIVT, FBTMLOG
 
       real*8  TTAU(L1_+1)
@@ -1222,7 +1225,7 @@
       enddo  ! k wavelength loop end
 
 !-----------------------------------------------------------------------
-       call MIESCT(FJ,FJTOP,FJBOT,FIBOT, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND)
+       call MIESCT(FJ,FJTOP,FJBOT,FIBOT, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND,RC)
 !-----------------------------------------------------------------------
 
 !---Integrate average std layer-L intensity from scatter array FJ(LZ=1:ND)
@@ -1270,7 +1273,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine MIESCT(FJ,FJT,FJB,FIB, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND)
+      subroutine MIESCT(FJ,FJT,FJB,FIB, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND,RC)
 !-----------------------------------------------------------------------
 
       integer, intent(in)  ::  LDOKR(W_+W_r),ND
@@ -1278,6 +1281,8 @@
                                ZTAU(N_,W_+W_r),RFL(5,W_+W_r),U0,FSBOT(W_+W_r)
       real*8,  intent(out) ::  FJ(N_,W_+W_r),FJT(W_+W_r)
       real*8,  intent(out) ::  FJB(W_+W_r),FIB(5,W_+W_r)
+      integer, intent(out) :: RC
+
       character(len=255)   ::  thisloc
       real*8  PM(M_,M2_),PM0(M2_)
       integer I, IM  ,K
@@ -1299,6 +1304,7 @@
 
       ! initialize location and outputs for safetly
       thisloc  = ' -> at MIESCT in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       FJ  = 0.d0
       FJT = 0.d0
       FJB = 0.d0
@@ -1312,7 +1318,7 @@
       enddo
 
 
-!---Note that U0 scattering does not change with altitude
+      !---Note that U0 scattering does not change with altitude
       call LEGND0 (-U0,PM0,M2_)
       do IM=1,M2_
          PM0(IM) = 0.25d0*PM0(IM)
@@ -1320,7 +1326,7 @@
 
 !---BLKSLV now called with all the wavelength arrays (K=1:W_)
 
-      call BLKSLV(FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJT,FJB,FIB,LDOKR,ND)
+      call BLKSLV(FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJT,FJB,FIB,LDOKR,ND,RC)
 
       END SUBROUTINE MIESCT
 
@@ -1355,7 +1361,7 @@
 
 !-----------------------------------------------------------------------
       subroutine BLKSLV &
-         (FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJTOP,FJBOT,FIBOT,LDOKR,ND)
+         (FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJTOP,FJBOT,FIBOT,LDOKR,ND,RC)
 !-----------------------------------------------------------------------
 !  Sets up and solves the block tri-diagonal system:
 !               A(I)*X(I-1) + B(I)*X(I) + C(I)*X(I+1) = H(I)
@@ -1369,6 +1375,7 @@
                               RFL(5,W_+W_r),FSBOT(W_+W_r)
       real*8, intent(out) ::  FJ(N_,W_+W_r),FJTOP(W_+W_r),FJBOT(W_+W_r), &
                               FIBOT(5,W_+W_r)
+      integer, intent(out) :: RC
 
       character(len=255)  ::  thisloc
       real*8, dimension(M_,N_,W_+W_r)    ::  A,C,H,   RR
@@ -1380,6 +1387,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at BLKSLV in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       FJ    = 0.d0
       FJTOP = 0.d0
       FJBOT = 0.d0
@@ -1389,7 +1397,7 @@
       if (LDOKR(K) .gt. 0) then
        call GEN_ID (POMEGA(1,1,K),FZ(1,K),ZTAU(1,K),FSBOT(K),RFL(1,K), &
              PM,PM0, B(1,1,1,K),CC(1,1,1,K),AA(1,1,1,K), &
-                     A(1,1,K),H(1,1,K),C(1,1,K), ND)
+                     A(1,1,K),H(1,1,K),C(1,1,K), ND, RC)
       endif
       enddo
 
@@ -1650,7 +1658,7 @@
 
 !-----------------------------------------------------------------------
       subroutine GEN_ID(POMEGA,FZ,ZTAU,ZFLUX,RFL,PM,PM0 &
-                    ,B,CC,AA,A,H,C,  ND)
+                    ,B,CC,AA,A,H,C,  ND,RC)
 !-----------------------------------------------------------------------
 !  Generates coefficient matrices for the block tri-diagonal system:
 !               A(I)*X(I-1) + B(I)*X(I) + C(I)*X(I+1) = H(I)
@@ -1663,6 +1671,7 @@
 
       real*8, intent(out),dimension(M_,M_,N_) ::  B,AA,CC
       real*8, intent(out),dimension(M_,N_) ::  A,C,H
+      integer, intent(out) :: RC
 
       character(len=255)  ::  thisloc
       integer I, J, K, L1,L2,LL
@@ -1674,6 +1683,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at GEN_ID in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       B  = 0.d0
       AA = 0.d0
       CC = 0.d0
@@ -1924,7 +1934,7 @@
 !<<<<<begin fastJX subroutines called from PHOTO_JX or OPMIE<<<<<<<<<<<<
 
 !------------------------------------------------------------------------------
-      subroutine OPTICL (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG)
+      subroutine OPTICL (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG,RC)
 !------------------------------------------------------------------------------
 ! new for FJ v7.5  for LIQUID water clouds only  interpolate properties to R_eff
 ! every S-bin has its own optical properties
@@ -1938,6 +1948,7 @@
       real*8, intent(out)::    QQEXT(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
+      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer I,J,K,L, NR
@@ -1945,6 +1956,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICL in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       DDENS = 0.d0
       QQEXT = 0.d0
       SSALB = 0.d0
@@ -1973,7 +1985,7 @@
 
 
 !------------------------------------------------------------------------------
-      subroutine OPTICI (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG)
+      subroutine OPTICI (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG,RC)
 !------------------------------------------------------------------------------
 ! new for FJ v7.5, parallel with liquid water, but two types of ice-water
 ! phase functions from a single calculation of Mishchenko, other opticals
@@ -1987,6 +1999,7 @@
       real*8, intent(out)::    QQEXT(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
+      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer I,J,K,L, NR
@@ -1994,6 +2007,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICI in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       DDENS = 0.d0
       QQEXT = 0.d0
       SSALB = 0.d0
@@ -2027,7 +2041,7 @@
 
 
 !------------------------------------------------------------------------------
-      subroutine OPTICS (OPTD,SSALB,SLEG, PATH,K)
+      subroutine OPTICS (OPTD,SSALB,SLEG, PATH,K,RC)
 !------------------------------------------------------------------------------
 !---for the UCI SSA (stratospheric sulfate aerosol) data sets
 !---UCI aersols optical data  v-7.4+
@@ -2042,9 +2056,10 @@
       real*8, intent(out)::    OPTD(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
       real*8, intent(out)::    SLEG(8,S_) ! scatt phase fn (Leg coeffs)
+      integer, intent(out) :: RC
 
       character(len=255)::     thisloc
-      integer I,J, KK, rc
+      integer I,J, KK
       real*8  XTINCT, REFF,RHO
 
       ! initialize location and outputs for safety
@@ -2080,7 +2095,7 @@
 
 
 !------------------------------------------------------------------------------
-      subroutine OPTICG (OPTD,SSALB,SLEG, PATH,K)
+      subroutine OPTICG (OPTD,SSALB,SLEG, PATH,K,RC)
 !------------------------------------------------------------------------------
 !---for the GEOMIP SSA (stratospheric sulfate aerosol) data sets
 ! K = 1001:1015 corresponds to R-eff = 0.02 0.04 0.08 0.10 ...  1.4 2.0 3.0
@@ -2092,6 +2107,7 @@
       real*8, intent(out)::    OPTD(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
       real*8, intent(out)::    SLEG(8,S_)  ! scatt phase fn (Leg coeffs)
+      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer I,J, KK
@@ -2099,6 +2115,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICG in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       OPTD  = 0.d0
       SSALB = 0.d0
       SLEG  = 0.d0
@@ -2120,7 +2137,7 @@
 
 
 !------------------------------------------------------------------------------
-      subroutine OPTICA (OPTD,SSALB,SLEG, PATH,RELH,K)
+      subroutine OPTICA (OPTD,SSALB,SLEG, PATH,RELH,K,RC)
 !------------------------------------------------------------------------------
 !---v-7.6+ no StratSulfAers (use OPTICS)  also interp/extrap a 1/wavelength
 !         std 5 wavelengths:200-300-400-600-999nm
@@ -2131,8 +2148,10 @@
         real*8, intent(in)::     PATH        ! path (g/m2) of aerosol/cloud
         real*8, intent(in)::     RELH        ! relative humidity (0.00->1.00+)
         integer,intent(inout)::     K        ! index of cloud/aerosols
+        integer, intent(out) :: RC
+
         character(len=255) ::    thisloc
-        integer I,J,JMIE, rc
+        integer I,J,JMIE
         real*8  XTINCT, REFF,RHO,WAVE, QAAX,SAAX,WAAX
 
         ! initialize location and outputs for safety
@@ -2192,7 +2211,7 @@
 
 
 !------------------------------------------------------------------------------
-      subroutine OPTICM (OPTD,SSALB,SLEG, PATH,RELH,LL)
+      subroutine OPTICM (OPTD,SSALB,SLEG, PATH,RELH,LL,RC)
 !------------------------------------------------------------------------------
 !---U Michigan aerosol data sets, this generate fast-JX data formats.
 !---Approximates the Legendre expansion(L) of the scattering phase fn as
@@ -2210,9 +2229,10 @@
       real*8, intent(in)::     PATH       ! path (g/m2) of aerosol/cloud
       real*8, intent(in)::     RELH       ! relative humidity (0.00->1.00)
       integer,intent(in)::     LL         ! index of cloud/aerosols
+      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
-      integer KR,J,L, JMIE, rc
+      integer KR,J,L, JMIE
       real*8  R,FRH, GCOS, XTINCT, WAVE
 
       ! initialize location and outputs for safety
@@ -2262,7 +2282,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine JRATET(PPJ,TTJ,FFF, VALJL,LU,NJXU)
+      subroutine JRATET(PPJ,TTJ,FFF, VALJL,LU,NJXU,RC)
 !-----------------------------------------------------------------------
 ! in:
 !        PPJ(L_+1) = pressure profile at edges
@@ -2276,12 +2296,13 @@
       real*8, intent(in)  ::  PPJ(LU+1),TTJ(LU+1)
       real*8, intent(inout)  ::  FFF(W_,LU)
       real*8, intent(out), dimension(LU,NJXU) ::  VALJL
+      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       real*8  VALJ(X_)
       real*8  QO2TOT, QO3TOT, QO31DY, QO31D, QQQT, TFACT
       real*8  TT,PP,DD,TT200,TFACA,TFAC0,TFAC1,TFAC2,QQQA,QQ2,QQ1A,QQ1B
-      integer J,K,L, IV, rc
+      integer J,K,L, IV
 
       ! initialize location and outputs for safety
       thisloc = ' -> at JRATET in module cldj_fjx_sub_mod.F90'
@@ -2317,11 +2338,11 @@
 !     for J=1:3  O2, O3(total), & O3(O1D)
         do K = 1,W_
           call X_interp (TT, QO2TOT, TQQ(1,1),QO2(K,1), TQQ(2,1), QO2(K,2), &
-                         TQQ(3,1),QO2(K,3), LQQ(1))
+                         TQQ(3,1),QO2(K,3), LQQ(1), RC)
           call X_interp (TT,QO3TOT, TQQ(1,2),QO3(K,1),TQQ(2,2),QO3(K,2), &
-                         TQQ(3,2),QO3(K,3), LQQ(2))
+                         TQQ(3,2),QO3(K,3), LQQ(2), RC)
           call X_interp (TT,QO31DY, TQQ(1,3),Q1D(K,1),TQQ(2,3),Q1D(K,2), &
-                         TQQ(3,3),Q1D(K,3), LQQ(3))
+                         TQQ(3,3),Q1D(K,3), LQQ(3), RC)
           QO31D  = QO31DY*QO3TOT
           VALJ(1) = VALJ(1) + QO2TOT*FFF(K,L)
           VALJ(2) = VALJ(2) + QO3TOT*FFF(K,L)
@@ -2333,10 +2354,10 @@
 !---also need to allow for Pressure interpolation if SQQ(J) = 'p'
             if (SQQ(J) .eq.'p') then
               call X_interp (PP,QQQT, TQQ(1,J),QQQ(K,1,J), &
-                   TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J))
+                   TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J), RC)
             else
               call X_interp (TT,QQQT, TQQ(1,J),QQQ(K,1,J), &
-                   TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J))
+                   TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J), RC)
             endif
               VALJ(J) = VALJ(J) + QQQT*FFF(K,L)
            enddo
@@ -2352,7 +2373,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine X_interp (TINT,XINT, T1,X1, T2,X2, T3,X3, L123)
+      subroutine X_interp (TINT,XINT, T1,X1, T2,X2, T3,X3, L123,RC)
 !-----------------------------------------------------------------------
 !  up-to-three-point linear interpolation function for X-sections
 !-----------------------------------------------------------------------
@@ -2360,12 +2381,14 @@
       real*8, intent(in)::  TINT,T1,T2,T3, X1,X2,X3
       integer,intent(in)::  L123
       real*8, intent(out)::  XINT
+      integer, intent(out) :: RC
 
       character(len=255)::  thisloc
       real*8  TFACT
 
       ! initialize location and outputs for safety
       thisloc = ' -> at X_interp in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       XINT = 0.d0
 
       if (L123 .le. 1) then
@@ -2387,7 +2410,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU6,POMEG6,JXTRA,LU)
+      subroutine JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU6,POMEG6,JXTRA,LU,RC)
 !-----------------------------------------------------------------------
 
 !-----------------------------------------------------------------------
@@ -2398,6 +2421,7 @@
       real*8, intent(in), dimension(LU+1) :: TTJ,DDJ,OOJ,DTAU6
       real*8, intent(in), dimension(8,LU+1) :: POMEG6
       integer,intent(in), dimension(LU+1) :: JXTRA
+      integer, intent(out) :: RC
 !-----------------------------------------------------------------------
       character(len=255)  ::  thisloc
       integer  I,J,K,L
@@ -2405,6 +2429,7 @@
 
       ! initialize
       thisloc = ' -> at JP_ATM in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
 
       write(6,'(4a)') '   L z(km)     p      T   ', &
        '    d(air)   d(O3)','  col(O2)  col(O3)     d-TAU   SS-alb', &
@@ -2432,7 +2457,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine JP_ATM0(PPJ,TTJ,DDJ,OOJ,ZZJ, LU)
+      subroutine JP_ATM0(PPJ,TTJ,DDJ,OOJ,ZZJ, LU,RC)
 !-----------------------------------------------------------------------
 
 !-----------------------------------------------------------------------
@@ -2442,12 +2467,14 @@
       integer,intent(in)                  :: LU
       real*8, intent(in), dimension(LU+2) :: PPJ,ZZJ
       real*8, intent(in), dimension(LU+1) :: TTJ,DDJ,OOJ
+      integer, intent(out) :: RC
 !-----------------------------------------------------------------------
       character(len=255)  ::  thisloc
       integer  I,J,K,L
       real*8   XCOLO2,XCOLO3,ZKM,DELZ,ZTOP
 
       thisloc = ' -> at JP_ATM0 in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
 
       write(6,'(4a)') '   L z(km)     p      T   ', &
        '    d(air)   d(O3)','  col(O2)  col(O3)     d-TAU   SS-alb', &
@@ -2473,7 +2500,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SPHERE1R (U0,RAD,ZHL,ZZHT,AMF, L1U)
+      subroutine SPHERE1R (U0,RAD,ZHL,ZZHT,AMF, L1U,RC)
 !-----------------------------------------------------------------------
 !  version 7.6  - SPHERE1N = drops the mid-layer (v6.2) for comp cost
 !     also 7.6  - SPHERE1R = adds refraction (complex ray tracing)
@@ -2505,6 +2532,7 @@
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
+      integer, intent(out) :: RC
 
       character(len=255)  ::   thisloc
       integer  L,L0, K,K0, LTOP
@@ -2515,9 +2543,9 @@
       real*8, dimension(L1_+1) :: RZ,DIVZ,RATZ,RD,RN, PATH1,PATH2,ZANG1
 
       ! initialize location and outputs for safety
-      thisloc = ' -> at SPHERE1R in module cldj_fjx_sub_mod.F90'
+      thisloc = " -> at SPHERE1R in module cldj_fjx_sub_mod.F90"
+      rc = CLDJ_SUCCESS
       AMF = 0.d0
-
 !-----------------------------------------------------------------------
 !  this versions sets a density scale ht of DDHT=8km, and a
 !        refractive index of 1.000300 at radius = RAD,
@@ -2710,7 +2738,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SPHERE1N (U0,RAD,ZHL,ZZHT,AMF, L1U)
+      subroutine SPHERE1N (U0,RAD,ZHL,ZZHT,AMF, L1U,RC)
 !-----------------------------------------------------------------------
 !  version 7.6a  - SPHERE1N = drops the mid-layer (v6.2) for comp cost
 !     also 7.6b  - SPHERE1R = adds refraction (complex ray tracing)
@@ -2735,6 +2763,7 @@
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
+      integer, intent(out) :: RC
 
       character(len=255)  ::   thisloc
       integer  L, J, JUP, LTOP, K
@@ -2744,6 +2773,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at SPHERE1N in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       AMF = 0.d0
 
       LTOP = L1U
@@ -2826,7 +2856,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SPHERE1F (U0,RAD,ZHL,ZZHT,AMF, L1U)
+      subroutine SPHERE1F (U0,RAD,ZHL,ZZHT,AMF, L1U,RC)
 !-----------------------------------------------------------------------
 !     needed for testing flat-disk errors
 !  version 7.6a  - SPHERE1N = drops the mid-layer (v6.2) for comp cost
@@ -2848,6 +2878,7 @@
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
+      integer, intent(out) :: RC
 
       character(len=255)  ::   thisloc
       integer  L, J, LTOP
@@ -2855,6 +2886,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at SPHERE1F in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       AMF = 0.d0
 
       LTOP = L1U
@@ -2875,7 +2907,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine EXTRAL1(DTAU600,L1X,NX,ATAU,ATAU0, JXTRA)
+      subroutine EXTRAL1(DTAU600,L1X,NX,ATAU,ATAU0, JXTRA,RC)
 !-----------------------------------------------------------------------
 !     version 7.6 replaces v 6.2 and drops back to no mid-layer J(odd) points.
 !   Purpose:  reduce spurious negative heating at top of thick clouds.
@@ -2902,8 +2934,10 @@
       real*8,  intent(in) ::  DTAU600(L1X)     !cloud+3aerosol OD in each layer
       real*8,  intent(in) ::  ATAU,ATAU0
       integer, intent(out)::  JXTRA(L1X)    !number of sub-layers to be added
+      integer, intent(out) :: RC
+
       character(len=255)  ::  thisloc
-      integer JTOTL,JX,L,LL, rc
+      integer JTOTL,JX,L,LL
       real*8  ATAULN,ATAU0X,AJX,DTAU0X
 
       ! initialize location and outputs for safety
@@ -2947,7 +2981,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SOLAR_JX(GMTIME,NDAY,YGRDJ,XGRDI, SZA,COSSZA,SOLFX)
+      subroutine SOLAR_JX(GMTIME,NDAY,YGRDJ,XGRDI, SZA,COSSZA,SOLFX,RC)
 !-----------------------------------------------------------------------
 ! >>>>>>>> warning tnot specific for SOLAR-J, is it old FAST_J call
 !     GMTIME = UT for when J-values are wanted
@@ -2963,12 +2997,14 @@
       real*8,  intent(in)  ::  GMTIME,YGRDJ,XGRDI
       integer, intent(in)  ::  NDAY
       real*8,  intent(out) ::  SZA,COSSZA,SOLFX
+      integer, intent(out) :: RC
 !
       character(len=255)   ::  thisloc
       real*8  LOCT
       real*8  SINDEC, SOLDEK, COSDEC, SINLAT, SOLLAT, COSLAT, COSZ
 
       thisloc = ' -> at SOLAR_JX in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
 
       SINDEC = 0.3978d0*sin(0.9863d0*(dble(NDAY)-80.d0)*CPI180)
       SOLDEK = asin(SINDEC)
@@ -2990,12 +3026,13 @@
 !SJ!    !!!!!!!!!!!!!!!!! SOLAR-J specific subroutines
 
 !---------------------------------------------------------------------
-      subroutine  FJX_CLIRAD_H2O(nlayers, PPP, TTT, HHH, TAUG_CLIRAD)
+      subroutine  FJX_CLIRAD_H2O(nlayers, PPP, TTT, HHH, TAUG_CLIRAD,RC)
 !---------------------------------------------------------------------
 
       integer,  intent(in):: nlayers
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
       real*8 ,  intent(out):: TAUG_CLIRAD(nlayers, 0:30)
+      integer, intent(out) :: RC
 
       character(len=255)  :: thisloc
       integer G, K, INDKG, L
@@ -3045,6 +3082,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at FJX_CLIRAD_H2O in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       TAUG_CLIRAD = 0.d0
 
 ! 0:0 will assign to bin 18 which is 0 for CLIRAD
@@ -3081,12 +3119,13 @@
 
 !!!!!!!!!!!!!!!!!!! SOLAR-J specific subroutines
 !---------------------------------------------------------------------
-      subroutine  FJX_GGLLNL_H2O(nlayers, PPP, TTT, HHH, TAUG_LLNL)
+      subroutine  FJX_GGLLNL_H2O(nlayers, PPP, TTT, HHH, TAUG_LLNL,RC)
 !---------------------------------------------------------------------
 
       integer,  intent(in):: nlayers
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
       real*8 ,  intent(out):: TAUG_LLNL(nlayers, 0:21)
+      integer, intent(out) :: RC
 
       character(len=255)  :: thisloc
       integer G, K, INDKG, L
@@ -3124,6 +3163,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at FJX_GGLLNL_H2O in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       TAUG_LLNL = 0.d0
 
       ! 0:0 will assign to bin 18 which is 0 for CLIRAD
@@ -3163,7 +3203,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine ACLIM_FJX (YLATD,MONTH,PPP, TTT,O3,CH4, L1U)
+      subroutine ACLIM_FJX (YLATD,MONTH,PPP, TTT,O3,CH4, L1U,RC)
 !-----------------------------------------------------------------------
 !  Load fast-JX climatology - T & O3 - for latitude & month & pressure grid
 !-----------------------------------------------------------------------
@@ -3172,6 +3212,8 @@
       integer, intent(in)  :: MONTH, L1U
       real*8,  intent(in),  dimension(L1U+1) :: PPP
       real*8,  intent(out), dimension(L1U)   :: TTT,O3,CH4
+      integer, intent(out) :: RC
+
       real*8, dimension(LREF)   :: OREF2,TREF2,HREF2,CREF2
       real*8, dimension(LREF+1) :: PSTD
       character(len=255)  ::  thisloc
@@ -3180,6 +3222,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_FJX in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       TTT = 0.d0
       O3  = 0.d0
       CH4 = 0.d0
@@ -3235,7 +3278,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine ACLIM_RH (PL, TL, QL, RH, L1U)
+      subroutine ACLIM_RH (PL, TL, QL, RH, L1U,RC)
 !-----------------------------------------------------------------------
 !  Calculates RH profile given PL(mid-pressure), TL(K), QL (spec hum)
 !  May nee RH @ L1U (top layer, not CTM) so aerosol calls are stable
@@ -3244,6 +3287,7 @@
       integer, intent(in):: L1U
       real*8,  intent(in),  dimension(L1U) :: PL,TL,QL
       real*8,  intent(out), dimension(L1U) :: RH
+      integer, intent(out) :: RC
 ! local variables
       character(len=255)  ::  thisloc
       real*8  T, eps, es, qs
@@ -3251,6 +3295,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_RH in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       RH = 0.d0
 
       eps=287.04d0/461.50d0
@@ -3272,7 +3317,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine ACLIM_GEO (YLATD,MONTH,PPP, AERS,NAER, L1U)
+      subroutine ACLIM_GEO (YLATD,MONTH,PPP, AERS,NAER, L1U,RC)
 !-----------------------------------------------------------------------
 !  Load GEOMIP SSA climatology (vs P) for latitude & month given pressure grid
 !-----------------------------------------------------------------------
@@ -3284,6 +3329,7 @@
       real*8,  intent(in),  dimension(L1U+1) :: PPP
       real*8,  intent(out), dimension(L1U)   :: AERS
       integer, intent(out), dimension(L1U)   :: NAER
+      integer, intent(out) :: RC
 
       character(len=255)  ::  thisloc
       real*8, dimension(LGREF+2) :: RREF2,XREF2,PREF2    ! param LGREF=19
@@ -3293,6 +3339,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_GEO in module cldj_fjx_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       AERS = 0.d0
       NAER = 0
 

--- a/src/Core/cldj_init_mod.F90
+++ b/src/Core/cldj_init_mod.F90
@@ -33,6 +33,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)           :: thisloc
       logical, intent(in)          :: AMIROOT
       character(LEN=*), intent(in) :: DATADIR
       integer, intent(in)          :: NLEVELS
@@ -44,6 +45,7 @@
       character*120  TIT_SPEC
       integer  JXUNIT,I, J, K, KR, RANSEED, NUN
 
+      thisloc = ' -> at INIT_CLDJ in module cldj_init_mod.F90'
       if (AMIROOT) write(6,*) ' Solar/Cloud-J  ver-7.7 initialization'
 
 #ifndef CLOUDJ_STANDALONE
@@ -130,7 +132,7 @@
 ! with Cloud-J v7.6, NO wavelength truncation for trop only, internal fixes
 ! remain
       if (W_ .ne. 18) then
-        call EXITC(' INIT_JX: invalid no. wavelengths')
+        call EXITC(' INIT_JX: invalid no. wavelengths', thisloc)
       endif
 
 ! set up angles of diffuse radiance at ocean surface
@@ -158,7 +160,7 @@
             if (AMIROOT) write(6,'(A,2I5)')'KR/KDOKR(KR)',KR, KDOKR(KR)
          enddo
       enddo
-      if (KR .ne. W_+W_r) CALL EXITC('>>>error w/ RRTM sub bins: KDOKR')
+      if (KR .ne. W_+W_r) CALL EXITC('>>>error w/ RRTM sub bins: KDOKR', thisloc)
       do KR = 1, W_+W_r
          K = KDOKR(KR)
          if (FL(K) .gt. 0.d0) then ! FL is read in call RD_XXX
@@ -211,7 +213,7 @@
 
       goto 1
     4 continue
-        call EXITC(' CLDJ_INIT: error in read')
+        call EXITC(' CLDJ_INIT: error in read', thisloc)
     1 continue
 
       if (AMIROOT) write(6,*) ' end of Solar/Cloud-J initialization'
@@ -249,6 +251,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
@@ -258,13 +261,15 @@
       character*6  TIT_J1S,TIT_J2S
       real*8  FWSUM
 
+      thisloc = ' -> at RD_XXX in module cldj_init_mod.F90'
+
       TQQ(:,:) = 0.d0
 
 !----------spectral data----set for new format data------------------
 !   note that X_ = max # Xsects read in
 !           NJX = # fast-JX J-values derived from this (.le. X_)
       if (W_ .ne. 18) then
-       call EXITC(' no. wavelengths wrong: W_ .ne. 18')
+       call EXITC(' no. wavelengths wrong: W_ .ne. 18', thisloc)
       endif
 
       open (NUN,FILE=trim(NAMFIL),status='old',form='formatted')
@@ -278,7 +283,7 @@
             NSSS, ' solar heating bins '
 
       if (NWWW.gt.WX_ .or. NSSS.gt.SX_) then
-       call EXITC(' WX_ or SX_ not large enough')
+       call EXITC(' WX_ or SX_ not large enough', thisloc)
       endif
 
       NW1 = 1
@@ -405,7 +410,7 @@
     2 continue
        JJ = JJ+1
        LQ = 1
-         if (JJ .gt. X_) call EXITC(' RD_XXX: X_ not large enough')
+         if (JJ .gt. X_) call EXITC(' RD_XXX: X_ not large enough', thisloc)
        TITLEJX(JJ) = TIT_J1S
        TITLEJL(JJ) = TIT_J1L
       read (NUN,'(a1,f3.0,1x,6e10.3/5x,6e10.3/5x,6e10.3)',err=4)    &
@@ -439,7 +444,7 @@
       endif
       goto 3
     4 continue
-        call EXITC(' RD_XXX: error in read')
+        call EXITC(' RD_XXX: error in read', thisloc)
     1 continue
       NJX = JJ
 
@@ -478,10 +483,10 @@
 !---need to check that TQQ (= T(K) or p(hPa)) is monotonically increasing:
       do J = 1,NJX
          if ((LQQ(J) .eq. 3) .and. (TQQ(2,J) .ge. TQQ(3,J))) then
-            call EXITC ('TQQ out of order')
+            call EXITC ('TQQ out of order', thisloc)
          endif
          if ((LQQ(J) .eq. 2) .and. (TQQ(1,J) .ge. TQQ(2,J))) then
-            call EXITC ('TQQ out of order')
+            call EXITC ('TQQ out of order', thisloc)
          endif
       enddo
 
@@ -527,6 +532,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
@@ -534,6 +540,8 @@
       integer  I,J,K,L, JCC
       character*120 TITLE0
       real*8     GCCJ, XNDR,XNDI
+
+      thisloc = ' -> at RD_CLD in module cldj_init_mod.F90'
 
       open (NUN,FILE=NAMFIL,status='old',form='formatted',err=4)
 
@@ -583,7 +591,7 @@
         goto 2
 
     4 continue
-        call EXITC(' RD_CLD: error in read')
+        call EXITC(' RD_CLD: error in read', thisloc)
 
     2 continue
         close(NUN)
@@ -612,6 +620,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
@@ -619,6 +628,8 @@
       integer  I, J, JSS, K, JCC, NSX_
       character*120 TITLE0
       real*8     WJSS,XNDR,XNDI
+
+      thisloc = ' -> at RD_SSA in module cldj_init_mod.F90'
 
       open (NUN,FILE=NAMFIL,status='old',form='formatted',err=4)
       read (NUN,'(a120)',err=4) TITLE0
@@ -652,7 +663,7 @@
       goto 2
 
     4 continue
-        call EXITC(' RD_SSA: error in read')
+        call EXITC(' RD_SSA: error in read', thisloc)
 
     2 continue
         close(NUN)
@@ -677,6 +688,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
@@ -687,6 +699,8 @@
 !      character*12 TITLAA(A_) 
       Character*12 TITLAAJ
       real*8   RAAJ, DAAJ
+
+      thisloc = ' -> at RD_MIE in module cldj_init_mod.F90'
 
       if (AMIROOT) write(6,'(i5,a)') NUN,trim(NAMFIL)
 
@@ -726,7 +740,7 @@
 
     4 continue
 
-      call EXITC(' RD_MIE: error in read')
+      call EXITC(' RD_MIE: error in read', thisloc)
 
     2 continue
 
@@ -745,6 +759,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
@@ -752,6 +767,8 @@
       integer  I, J, K, L
       character*78 TITLE0
       character*20 TITLUM(33)   ! TITLUM: Title for U Michigan aerosol data set
+
+      thisloc = ' -> at RD_UM in module cldj_init_mod.F90'
 
       open (NUN,FILE=NAMFIL,status='old',form='formatted')
 
@@ -796,6 +813,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) ::  NJ2
       character(*), intent(in) ::  NAMFIL
@@ -805,6 +823,7 @@
 
       character*78 TITLE0
 !
+      thisloc = ' -> at RD_PROF in module cldj_init_mod.F90'
       open (NJ2,file=NAMFIL,status='old',form='formatted')
       read (NJ2,'(A)') TITLE0
       read (NJ2,'(2I5)') NTLATS,NTMONS
@@ -855,6 +874,7 @@
 !-----------------------------------------------------------------------
       implicit none
 
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) ::  NJ2
       character(*), intent(in) ::  NAMFIL
@@ -863,6 +883,7 @@
 
       character*78 TITLE0
 !
+      thisloc = ' -> at RD_TRPROF in module cldj_init_mod.F90'
       open (NJ2,file=NAMFIL,status='old',form='formatted')
       read (NJ2,'(A)') TITLE0
       read (NJ2,'(2I5)') NTLATS,NTMONS
@@ -916,6 +937,7 @@
 !-----------------------------------------------------------------------
       implicit none
 !
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in)                    ::  NUNIT, NJX
       character(*), intent(in)               ::  NAMFIL
@@ -926,6 +948,7 @@
       character*6  T_FJX
       real*8 F_FJX
 
+      thisloc = ' -> at RD_JS_JX in module cldj_init_mod.F90'
 ! Read the FJX_j2j.dat file to map model specific J's onto fast-JX J's
 ! The chemistry code title describes fully the reaction (a50)
 ! Blank (unfilled) chemistry J's are unmapped
@@ -1008,6 +1031,8 @@
 !     PGG      Phase function: first 8 terms of expansion
 !-----------------------------------------------------------------------
       implicit none
+
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) :: NUN
       character(*), intent(in) ::  NAMFIL
@@ -1015,6 +1040,8 @@
       integer  I, J, K
       character*120 TITLE0
       real*8     WGGJ,XNDR,XNDI,G1,G2,G3
+
+      thisloc = ' -> at RD_GEO in module cldj_init_mod.F90'
 
       open (NUN,FILE=NAMFIL,status='old',form='formatted',err=4)
 
@@ -1046,7 +1073,7 @@
       goto 2
 
     4 continue
-      call EXITC(' RD_GEO: error in read')
+      call EXITC(' RD_GEO: error in read', thisloc)
 
     2 continue
       close(NUN)
@@ -1062,6 +1089,8 @@
 !      X_GEO = mass fraction (1e-9 kg-H2SO4/kg-air)
 !-----------------------------------------------------------------------
       implicit none
+
+      character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
       integer, intent(in) ::  NJ2
       character(*), intent(in) ::  NAMFIL
@@ -1069,6 +1098,7 @@
       integer J,L,M
       character*78 TITLE0
 !
+      thisloc = ' -> at RD_SSAPROF in module cldj_init_mod.F90'
       open (NJ2,file=NAMFIL,status='old',form='formatted')
       read (NJ2,'(a)') TITLE0
          if (AMIROOT) write(6,'(1x,a)') TITLE0
@@ -1126,6 +1156,8 @@
 !  generates a sequence of real*4 pseudo-random numbers RAN4L(1:ND)
 !     program RAN3 from Press, based on Knuth
       implicit none
+
+      character(len=255) ::  thisloc
       integer, parameter ::  MBIG=1000000000
       integer, parameter ::  MSEED=161803398
       integer, parameter ::  MZ=0
@@ -1134,6 +1166,8 @@
       real*4, intent(out)   :: RAN4L(ND)
       integer,intent(inout) :: ISTART
       integer :: MA(55),MJ,MK,I,II,J,K,INEXT,INEXTP
+
+      thisloc = ' -> at RANSET in module cldj_init_mod.F90'
 !---initialization and/or fix of ISEED < 0
         MJ = MSEED - abs(ISTART)
         MJ = mod(MJ,MBIG)

--- a/src/Core/cldj_init_mod.F90
+++ b/src/Core/cldj_init_mod.F90
@@ -133,7 +133,7 @@
 ! with Cloud-J v7.6, NO wavelength truncation for trop only, internal fixes
 ! remain
       if (W_ .ne. 18) then
-        call CLOUDJ_ERROR(' INIT_JX: invalid no. wavelengths', thisloc, rc)
+        call CLOUDJ_ERROR('Invalid no. wavelengths', thisloc, rc)
         return
       endif
 
@@ -146,6 +146,10 @@
 
 ! Read in Fast/Solar-J X-sections (spectral data)
       call RD_XXX(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_spec.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_XXX', thisloc, rc)
+         return
+      endif
 
       if (.not.(LRRTMG .or. LCLIRAD .or. LGGLLNL)) then
          do I = W_,  S_
@@ -177,27 +181,59 @@
 
 ! Read in cloud scattering data
       call RD_CLD(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-cld.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_CLD', thisloc, rc)
+         return
+      endif
 
 ! Read in strat sulf aerosols scattering data
       call RD_SSA(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-ssa.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_SSA', thisloc, rc)
+         return
+      endif
 
 ! Read in aerosols scattering data
       call RD_MIE(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-aer.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_MIE', thisloc, rc)
+         return
+      endif
 
 ! Read in UMich aerosol scattering data
       call RD_UM (AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-UMa.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_UM', thisloc, rc)
+         return
+      endif
 
 ! Read in GEOMIP aerosol scattering data
       call RD_GEO (AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_scat-geo.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_GEO', thisloc, rc)
+         return
+      endif
 
 ! Read in T & O3 climatology used to fill e.g. upper layers or if O3 not calc.
       call RD_PROF(AMIROOT,JXUNIT,TRIM(DATADIR)//'atmos_std.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_PROF', thisloc, rc)
+         return
+      endif
 
 ! Read in H2O and CH4 profiles for Solar-J
       call RD_TRPROF(AMIROOT,JXUNIT,TRIM(DATADIR)//'atmos_h2och4.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_TRPROF', thisloc, rc)
+         return
+      endif
 
 ! Read in zonal mean Strat-Sulf-Aerosol monthly data
       call RD_SSAPROF(AMIROOT,JXUNIT,TRIM(DATADIR)//'atmos_geomip.dat',rc)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_SSAPROF', thisloc, rc)
+         return
+      endif
 
       NJXX = NJX
       do J = 1,NJXX
@@ -207,18 +243,30 @@
 ! Read in photolysis rates used in chemistry code and mapping onto FJX J's
 !---CTM call:  read in J-values names and link to fast-JX names
       call RD_JS_JX(AMIROOT,JXUNIT,TRIM(DATADIR)//'FJX_j2j.dat', TITLEJXX,NJXX,RC)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RD_JS_JX', thisloc, rc)
+         return
+      endif
 
 !---for full ASAD:
 !     call RD_JS(JXUNIT,TRIM(DATADIR)//'ratj.d', TITLEJXX,NJXX,TSPECI,JPSPEC  &
 !                ,MJVAL,TJVAL,MJX,rc)
+!      if ( rc /= CLDJ_SUCCESS ) then
+!         call CLOUDJ_ERROR('Error in RD_JS', thisloc, rc)
+!         return
+!      endif
 
 !---setup the random number sequence RAN4
       RANSEED = 66
       call RANSET (NRAN_,RAN4,RANSEED,RC)
+      if ( rc /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR('Error in RANSET', thisloc, rc)
+         return
+      endif
 
       goto 1
     4 continue
-      call CLOUDJ_ERROR(' CLDJ_INIT: error in read', thisloc, rc)
+      call CLOUDJ_ERROR('Error in read', thisloc, rc)
       return
 
     1 continue
@@ -422,7 +470,7 @@
        JJ = JJ+1
        LQ = 1
        if (JJ .gt. X_) then
-          call CLOUDJ_ERROR(' RD_XXX: X_ not large enough', thisloc, rc)
+          call CLOUDJ_ERROR('X_ not large enough', thisloc, rc)
           return
        endif
        TITLEJX(JJ) = TIT_J1S
@@ -458,7 +506,7 @@
       endif
       goto 3
     4 continue
-      call CLOUDJ_ERROR(' RD_XXX: error in read', thisloc, rc)
+      call CLOUDJ_ERROR('Error in read', thisloc, rc)
       return
 
     1 continue
@@ -610,7 +658,7 @@
         goto 2
 
     4 continue
-        call CLOUDJ_ERROR(' RD_CLD: error in read', thisloc, rc)
+        call CLOUDJ_ERROR('Error in read', thisloc, rc)
         return
         
     2 continue
@@ -684,7 +732,7 @@
       goto 2
 
     4 continue
-      call CLOUDJ_ERROR(' RD_SSA: error in read', thisloc, rc)
+      call CLOUDJ_ERROR('Error in read', thisloc, rc)
       return
 
     2 continue
@@ -762,7 +810,7 @@
       goto 2
 
     4 continue
-      call CLOUDJ_ERROR(' RD_MIE: error in read', thisloc, rc)
+      call CLOUDJ_ERROR('Error in read', thisloc, rc)
       return
 
     2 continue
@@ -1102,7 +1150,7 @@
       goto 2
 
     4 continue
-      call CLOUDJ_ERROR(' RD_GEO: error in read', thisloc, rc)
+      call CLOUDJ_ERROR('Error in read', thisloc, rc)
       return
 
     2 continue

--- a/src/Core/cldj_init_mod.F90
+++ b/src/Core/cldj_init_mod.F90
@@ -31,7 +31,6 @@
       subroutine INIT_CLDJ (AMIROOT,DATADIR,NLEVELS,NLEVELS_WITH_CLOUD, &
                             TITLEJXX,NJXU,NJXX)
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)           :: thisloc
       logical, intent(in)          :: AMIROOT
@@ -249,7 +248,6 @@
 !     TQQ      Temperature for supplied cross sections
 !     QQQ      Supplied cross sections in each wavelength bin (cm2)
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -530,7 +528,6 @@
 !     SCC      Single scattering albedo
 !     DCC      density (g/cm^3)
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -618,7 +615,6 @@
 !     SSS      Single scattering albedo
 !     DSS      density (g/cm^3)
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -686,7 +682,6 @@
 !     SAA      Single scattering albedo
 !     DAA      density (g/cm^3)
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -757,7 +752,6 @@
 !     NAMFIL   Name of scattering data file (e.g., FJX_scat.dat)
 !     NUN      Channel number for reading data file
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -811,7 +805,6 @@
 !-----------------------------------------------------------------------
 !  Routine to input T and O3 reference profiles 'atmos_std.dat'
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -872,7 +865,6 @@
 !-----------------------------------------------------------------------
 !  Routine to input H2O and CH4 reference profiles 'atmos_h2och4.dat'
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -935,7 +927,6 @@
 !     NRATJ     number of Photolysis reactions in CTM chemistry, derived here
 !                   NRATJ must be .le. JVN_
 !-----------------------------------------------------------------------
-      implicit none
 !
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -1030,7 +1021,6 @@
 !     SGG      Single scattering albedo
 !     PGG      Phase function: first 8 terms of expansion
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -1088,7 +1078,6 @@
 !      R_GEO = effective radius (microns)
 !      X_GEO = mass fraction (1e-9 kg-H2SO4/kg-air)
 !-----------------------------------------------------------------------
-      implicit none
 
       character(len=255)  :: thisloc
       logical, intent(in) :: AMIROOT
@@ -1155,7 +1144,6 @@
 !-----------------------------------------------------------------------
 !  generates a sequence of real*4 pseudo-random numbers RAN4L(1:ND)
 !     program RAN3 from Press, based on Knuth
-      implicit none
 
       character(len=255) ::  thisloc
       integer, parameter ::  MBIG=1000000000

--- a/src/Core/cldj_osa_sub_mod.F90
+++ b/src/Core/cldj_osa_sub_mod.F90
@@ -17,8 +17,6 @@ MODULE CLDJ_OSA_SUB_MOD
 
 SUBROUTINE OSA(WAVEL,WIND,CHLORa, Cangles, OSA_dir)
 
-IMPLICIT NONE
-
 ! Number of wavelength (200nm - 4000nm by 10nm apart)
 INTEGER, PARAMETER   :: NNWL = 381
 

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -6,7 +6,8 @@
       MODULE CLDJ_SUB_MOD
 
       USE CLDJ_CMN_MOD
-      USE CLDJ_FJX_SUB_MOD,  ONLY: PHOTO_JX, EXITC
+      USE CLDJ_ERROR_MOD
+      USE CLDJ_FJX_SUB_MOD,  ONLY: PHOTO_JX
 
       IMPLICIT NONE
 
@@ -130,7 +131,7 @@
 !-----------------------------------------------------------------------
       character(len=255)          :: thisloc
       logical  LPRTJ0
-      integer  I,II,J,K,L,M,N, LTOP, NRG,IRANX
+      integer  I,II,J,K,L,M,N, LTOP, NRG,IRANX, rc
       real*8   CLDFR, XRAN, FSCALE, QCAOD, WTRAN
       real*8,  dimension(L1U)     :: LWPX,IWPX,REFFLX,REFFIX
       real*8,  dimension(LWEPAR)  :: CLTL,CLTI, CLT,CLDX
@@ -152,6 +153,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at CLOUD_JX in module cldj_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       LPRTJ0  = LPRTJ
       JCOUNT  = 0
       NICA    = 0
@@ -171,7 +173,7 @@
 !---CLOUD_JX:   different cloud schemes
 !-----------------------------------------------------------------------
       if (CLDFLAG.lt.1 .or. CLDFLAG.gt.8)then
-         call EXITC ('>>>stop, incorrect cloud index', thisloc)
+         call CLOUDJ_ERROR('>>>stop, incorrect cloud index', thisloc, rc)
       endif
 
 !--------------------CLDFLAG =  1, 2, 3---------------------------------
@@ -273,7 +275,7 @@
 !-----------------------------------------------------------------------
 ! 4 = average direct beam over all ICAs  DISCONTINUED
          if (CLDFLAG .eq. 4) then
-            call EXITC(' CLD FLAG = 4 not allowed', thisloc)
+            call CLOUDJ_ERROR(' CLD FLAG = 4 not allowed', thisloc, rc)
          endif
 
 !-----------------------------------------------------------------------

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -30,7 +30,7 @@
       SUBROUTINE CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,  &
              RRR,OOO,CCC, LWP,IWP,REFFL,REFFI, CLDF,CLDCOR,CLDIW,      &
              AERSP,NDXAER,L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18,      &
-             IRAN,NICA, JCOUNT,LDARK,WTQCA)
+             IRAN,NICA, JCOUNT,LDARK,WTQCA,RC)
 
 !---Current recommendation for best average J's is
 !     1) cloud decorellation w/ max-overlap blocks:  LNRG = 6 and CLDCOR = 0.33
@@ -128,10 +128,11 @@
       integer, intent(out)                     :: NICA
       integer, intent(out)                     :: JCOUNT
       logical, intent(out)                     :: LDARK
+      integer, intent(out)                     :: RC
 !-----------------------------------------------------------------------
       character(len=255)          :: thisloc
       logical  LPRTJ0
-      integer  I,II,J,K,L,M,N, LTOP, NRG,IRANX, rc
+      integer  I,II,J,K,L,M,N, LTOP, NRG,IRANX
       real*8   CLDFR, XRAN, FSCALE, QCAOD, WTRAN
       real*8,  dimension(L1U)     :: LWPX,IWPX,REFFLX,REFFIX
       real*8,  dimension(LWEPAR)  :: CLTL,CLTI, CLT,CLDX
@@ -219,7 +220,7 @@
 !-----------------------------------------------------------------------
          call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,       &
                   DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,       &
-                  NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK)
+                  NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK, RC)
          if (.not.LDARK) then
             JCOUNT = JCOUNT + 1
          endif
@@ -261,12 +262,12 @@
 !---CLT(cloud ice+liq OD) & IWPX & LWPX adjusted to quantized cld fr
 !-------------------------------------------------------------------------
          call ICA_NR(LPRTJ0,CLDX,CLT,IWPX,LWPX,ZZZ, CLDIW,LTOP,CBIN_,ICA_, &
-             CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA)
+             CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,RC)
 
 !---call ICA_ALL to generate the weight and cloud total OD of each ICA
 !-------------------------------------------------------------------------
          call ICA_ALL(LPRTJ0,CLDX,CLT,LTOP,CBIN_,ICA_, CFBIN,     &
-            CLDCOR,NCLDF,GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL)
+            CLDCOR,NCLDF,GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL,RC)
 
          if(LPRTJ0) then
             write(6,*) ' cloud-J v7.7  internal print:  #ICAs = ',NICA
@@ -299,7 +300,7 @@
                enddo
 
                call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR, &
-                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
+                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
 
 !---zero out cloud water paths which are not in the selected random ICA
                do L = 1, LTOP
@@ -324,7 +325,7 @@
 !-----------------------------------------------------------------------
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                      DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,        &
-                     NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK)
+                     NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
                endif
@@ -354,7 +355,7 @@
          if (CLDFLAG .eq. 6) then
 
             call ICA_QUD(WCOL,OCOL,ICA_,NQD_,NICA, &
-                         WTQCA, ISORT,NQ1,NQ2,NDXQS)
+                         WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
 
             if (LPRTJ0) then
                write(6,'(a)') ' quadrature QCAs(mid-pt): wt/range/index/OD'
@@ -370,7 +371,7 @@
                   I = ISORT(NDXQS(N))
 
                   call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR,  &
-                                GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
+                                GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
 
 !---zero out cloud water paths which are not in the selected QCA
                   do L = 1, LTOP
@@ -386,7 +387,7 @@
 !-----------------------------------------------------------------------
                   call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH, &
                    DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,     &
-                   NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK)
+                   NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK, RC)
                   if (.not.LDARK) then
                      JCOUNT = JCOUNT + 1
                   endif
@@ -417,7 +418,7 @@
          if (CLDFLAG .eq. 7) then
 
             call ICA_QUD(WCOL,OCOL,ICA_,NQD_,NICA, &
-                         WTQCA, ISORT,NQ1,NQ2,NDXQS)
+                         WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
 
             if (LPRTJ0) then
                write(6,'(a)') ' quadrature QCAs(avg-cld): wt/range/index/OD'
@@ -435,7 +436,7 @@
                         I = ISORT(II)
 
                         call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR, &
-                                      GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
+                                      GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
 
                         if (LPRTJ0) then
                            write(6,'(a,3i5,2f8.4,f9.3)') &
@@ -469,7 +470,7 @@
 !-----------------------------------------------------------------------
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                     DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
-                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK)
+                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
                      if (.not.LDARK) then
                         JCOUNT = JCOUNT + 1
                      endif
@@ -508,7 +509,7 @@
             endif
             do I = 1, NICA
                call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR,  &
-                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
+                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
 !---zero out cloud water paths which are not in the selected random ICA
                do L = 1, LTOP
                   LWPX(L) = LWP(L)
@@ -523,7 +524,7 @@
 !-----------------------------------------------------------------------
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                     DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
-                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK)
+                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
                endif
@@ -556,7 +557,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_NR(LPRTJ0,CLDF,CLTAU,IWPX,LWPX,ZZZ,CLDIW,LTOP,CBIN_, &
-            ICA_,CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA)
+            ICA_,CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,RC)
 !-----------------------------------------------------------------------
 !---revised in v7.7 (02/2020) fixed MAX-RAN (#0 & #3) set CLDCOR=0 if need be
 !---Read in the cloud fraction (CLDF), cloud OD (CLTAU), cloud index (CLDIW)
@@ -611,6 +612,7 @@
       integer, intent(out), dimension(9) :: GBOT,GTOP,GLVL,GNR,GCMX
       integer, intent(out), dimension(9,CBIN_+1) :: GFNR
       real*8,  intent(out), dimension(CBIN_) :: CFBIN
+      integer, intent(out) :: RC
 
       character(len=255)        :: thisloc
       real*8   FBIN, FSCALE, CLF_MIN, CLF_MAX, FSCALE2
@@ -623,6 +625,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_NR in module cldj_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       NRG   = 0
       NICA  = 0
       NCLDF = 0
@@ -941,7 +944,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_ALL(LPRTJ0,CLF,CLT,LTOP,CBINU,ICAU, CFBIN,CLDCOR,NCLDF,  &
-           GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL)
+           GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL,RC)
 !-----------------------------------------------------------------------
 !    OCOL() = cloud optical depth (total) in each ICA
 !    WCOL() = weight(fract area) of ICA,
@@ -967,6 +970,7 @@
       real*8,  intent(in), dimension(CBINU) :: CFBIN
       real*8,  intent(in)                   :: CLDCOR
       real*8,  intent(out),dimension(ICAU)  :: WCOL,OCOL
+      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       real*8  ODCOL,WTCOL,CF0(51),  FWT(10,51),FWTC(10,51),FWTCC(10,51)
@@ -977,6 +981,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_ALL in module cldj_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       WCOL = 0.d0
       OCOL = 0.d0
 
@@ -1093,7 +1098,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_III(LPRTJ0, CLT,  LTOP, CBINU, III,  NCLDF, GFNR, &
-                         GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
+                         GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
 !-----------------------------------------------------------------------
 !    see ICA_ALL, this subroutine picks out the ICA atmosphere #III
 !      and loads the REFF/WPs for a FAST_JX calculation.
@@ -1105,6 +1110,7 @@
       integer, intent(in), dimension(9,CBINU+1) :: GFNR
       real*8,  intent(in), dimension(LTOP)  :: CLT
       real*8,  intent(out),dimension(LTOP)  :: TTCOL
+      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer II, IG, G, L
@@ -1112,6 +1118,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_III in module cldj_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       TTCOL = 0.d0
 
       TTCOL = 0.d0
@@ -1131,7 +1138,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_QUD(WCOL,OCOL, ICAU,NQDU,NICA, &
-                         WTQCA, ISORT,NQ1,NQ2,NDXQS)
+                         WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
 !-----------------------------------------------------------------------
 !---Take the full set of ICAs and group into the NQD_ ranges of total OD
 !---Create the Cumulative Prob Fn and select the mid-point ICA for each group
@@ -1144,6 +1151,7 @@
       real*8, intent(out), dimension(NQDU)      :: WTQCA
       integer, intent(out), dimension(ICAU)     :: ISORT
       integer, intent(out), dimension(NQDU)     :: NQ1,NQ2,NDXQS
+      integer, intent(out) :: RC
 
       character(len=255)       :: thisloc
       real*8,  dimension(ICA_) :: OCDFS, OCOLS
@@ -1154,6 +1162,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_QUD in module cldj_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       ISORT = 0
       NQ1   = 0
       NQ2   = 0
@@ -1172,7 +1181,7 @@
         ISORT(1) = 1
         OCOLS(1) = OCOL(1)
       else
-        call HEAPSORT_A (NICA,OCOL,OCOLS,ISORT,ICA_)
+        call HEAPSORT_A (NICA,OCOL,OCOLS,ISORT,ICA_,RC)
       endif
         OCDFS(1) = WCOL(ISORT(1))
       do I = 2,NICA
@@ -1213,7 +1222,7 @@
 
 
 !-----------------------------------------------------------------------
-      SUBROUTINE HEAPSORT_A (N,A,AX,IX,ND)
+      SUBROUTINE HEAPSORT_A (N,A,AX,IX,ND,RC)
 !-----------------------------------------------------------------------
 !  classic heapsort, sorts real*8 array A(N) into ASCENDING order,
 !     places sorted array AX(N):   AX(1) .le. AX(N)
@@ -1226,6 +1235,8 @@
       real*8, dimension(ND),intent(in)  :: A
       real*8, dimension(ND),intent(out) :: AX
       integer,dimension(ND),intent(out) :: IX
+      integer, intent(out) ::RC
+
       character(len=255) :: thisloc
       integer :: I,J,L,IR,IA
       real*8 :: RA
@@ -1233,6 +1244,7 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at HEAPSORT_A in module cldj_sub_mod.F90'
+      rc = CLDJ_SUCCESS
       AX = 0.d0
       IX = 0
 

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -128,6 +128,7 @@
       integer, intent(out)                     :: JCOUNT
       logical, intent(out)                     :: LDARK
 !-----------------------------------------------------------------------
+      character(len=255)          :: thisloc
       logical  LPRTJ0
       integer  I,II,J,K,L,M,N, LTOP, NRG,IRANX
       real*8   CLDFR, XRAN, FSCALE, QCAOD, WTRAN
@@ -148,6 +149,7 @@
       real*8,  dimension(L1U)       :: OD18Q
 
 !-----------------------------------------------------------------------
+      thisloc = ' -> at CLOUD_JX in module cldj_sub_mod.F90'
       LPRTJ0 = LPRTJ
       JCOUNT = 0
       NICA = 0
@@ -169,7 +171,7 @@
 !---CLOUD_JX:   different cloud schemes
 !-----------------------------------------------------------------------
       if (CLDFLAG.lt.1 .or. CLDFLAG.gt.8)then
-         call EXITC ('>>>stop, incorrect cloud index')
+         call EXITC ('>>>stop, incorrect cloud index', thisloc)
       endif
 
 !--------------------CLDFLAG =  1, 2, 3---------------------------------
@@ -271,7 +273,7 @@
 !-----------------------------------------------------------------------
 ! 4 = average direct beam over all ICAs  DISCONTINUED
          if (CLDFLAG .eq. 4) then
-            call EXITC(' CLD FLAG = 4 not allowed')
+            call EXITC(' CLD FLAG = 4 not allowed', thisloc)
          endif
 
 !-----------------------------------------------------------------------
@@ -609,6 +611,7 @@
       integer, intent(out), dimension(9,CBIN_+1) :: GFNR
       real*8,  intent(out), dimension(CBIN_) :: CFBIN
 
+      character(len=255)        :: thisloc
       real*8   FBIN, FSCALE, CLF_MIN, CLF_MAX, FSCALE2
       integer                   ::  NRGX, NICAX
       integer, dimension(9)  :: GMIN,GMAX
@@ -616,6 +619,8 @@
       integer  I,K,L,LL,N,NC, L1,L2,L3,  LCLTOP,LCIRRUS
       logical  L1GRP,L2GRP,L3GRP, L6GRP
 !-----------------------------------------------------------------------
+
+      thisloc = ' -> at ICA_NR in module cldj_sub_mod.F90'
 
 !---quantize cloud fractions into bins to avoid excessive calculations for
 !---  nearly identical maximally overlapping cloud fractions.
@@ -951,12 +956,16 @@
       real*8,  intent(in)                   :: CLDCOR
       real*8,  intent(out),dimension(ICAU)  :: WCOL,OCOL
 
+      character(len=255) :: thisloc
       real*8  ODCOL,WTCOL,CF0(51),  FWT(10,51),FWTC(10,51),FWTCC(10,51)
       real*8  FIG1,FIG2,GCORR,GCOWT,CORRFAC, FCMX(10) ,CLTOT(100)
       integer I, II, IG1,IG2, G, L,  IGNR(10),GCLDY(10),GRP1,GRP2
       logical L_CLR1,L_CLR2  ,LSKIP   ,LGR_CLR(10)
 !-----------------------------------------------------------------------
-        CLTOT(:) = 0.d0
+
+      thisloc = ' -> at ICA_ALL in module cldj_sub_mod.F90'
+
+      CLTOT(:) = 0.d0
 
         CF0(1) = 0.d0
       do L = 1,CBINU
@@ -1082,9 +1091,13 @@
       real*8,  intent(in), dimension(LTOP)  :: CLT
       real*8,  intent(out),dimension(LTOP)  :: TTCOL
 
+      character(len=255) :: thisloc
       integer II, IG, G, L
 !-----------------------------------------------------------------------
-         TTCOL(:) = 0.d0
+
+      thisloc = ' -> at ICA_III in module cldj_sub_mod.F90'
+
+      TTCOL(:) = 0.d0
       II = max(1, min(NICA,III))
       do G = 1,NRG
           IG = mod(II-1, GNR(G)) + 1
@@ -1115,11 +1128,15 @@
       integer, intent(out), dimension(ICAU)     :: ISORT
       integer, intent(out), dimension(NQDU)     :: NQ1,NQ2,NDXQS
 
+      character(len=255)       :: thisloc
       real*8,  dimension(ICA_) :: OCDFS, OCOLS
       integer I, II, J, L, N, N1, N2
 
       real*8, parameter:: OD_QUAD(4) =[0.5d0, 4.0d0, 30.d0, 1.d9]
 !-----------------------------------------------------------------------
+
+      thisloc = ' -> at ICA_QUD in module cldj_sub_mod.F90'
+
       ISORT(:) = 0
       WTQCA(:)  = 0.d0
       NDXQS(:) = 0
@@ -1187,9 +1204,13 @@
       real*8, dimension(ND),intent(in)  :: A
       real*8, dimension(ND),intent(out) :: AX
       integer,dimension(ND),intent(out) :: IX
+      character(len=255) :: thisloc
       integer :: I,J,L,IR,IA
       real*8 :: RA
 !-----------------------------------------------------------------------
+
+      thisloc = ' -> at HEAPSORT_A in module cldj_sub_mod.F90'
+
       do I = 1,N
         IX(I) = I
         AX(I) = A(I)

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -149,24 +149,24 @@
       real*8,  dimension(L1U)       :: OD18Q
 
 !-----------------------------------------------------------------------
+
+      ! initialize location and outputs for safety
       thisloc = ' -> at CLOUD_JX in module cldj_sub_mod.F90'
-      LPRTJ0 = LPRTJ
-      JCOUNT = 0
-      NICA = 0
-      do L = LWEPAR+1, L1U
-         LWPX(L) = 0.d0
-         IWPX(L) = 0.d0
-         REFFLX(L) = 0.d0
-         REFFIX(L) = 0.d0
-      enddo
-      VALJXX(:,:) = 0.d0    ! zero J's Heating R's in case LDARK is returned
-      SKPERD(:,:) = 0.d0
-      SWMSQ(:)    = 0.d0
-      VALJXXX(:,:) = 0.d0   ! zero the PHOTOJ equivalents for wtd averaging
-      SKPERDD(:,:) = 0.d0
-      SWMSQQ(:)    = 0.d0
-      OD18(:)      = 0.d0
-      OD18Q(:)     = 0.d0
+      LPRTJ0  = LPRTJ
+      JCOUNT  = 0
+      NICA    = 0
+      LWPX    = 0.d0
+      IWPX    = 0.d0
+      REFFLX  = 0.d0
+      REFFIX  = 0.d0
+      VALJXX  = 0.d0   ! zero J's Heating R's in case LDARK is returned
+      SKPERD  = 0.d0
+      SWMSQ   = 0.d0
+      VALJXXX = 0.d0   ! zero the PHOTOJ equivalents for wtd averaging
+      SKPERDD = 0.d0
+      SWMSQQ  = 0.d0
+      OD18    = 0.d0
+      OD18Q   = 0.d0
 
 !---CLOUD_JX:   different cloud schemes
 !-----------------------------------------------------------------------
@@ -426,8 +426,8 @@
             do N = 1, NQD_
                if (WTQCA(N) .gt. 0.d0) then
                   if (NQ2(N) .ge. NQ1(N)) then
-                     IWPX(:) = 0.d0
-                     LWPX(:) = 0.d0
+                     IWPX = 0.d0
+                     LWPX = 0.d0
                      QCAOD = 0.d0
                      do II = NQ1(N),NQ2(N)
                         I = ISORT(II)
@@ -619,7 +619,18 @@
       logical  L1GRP,L2GRP,L3GRP, L6GRP
 !-----------------------------------------------------------------------
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at ICA_NR in module cldj_sub_mod.F90'
+      NRG   = 0
+      NICA  = 0
+      NCLDF = 0
+      GBOT  = 0
+      GTOP  = 0
+      GLVL  = 0
+      GNR   = 0
+      GCMX  = 0
+      GFNR  = 0
+      CFBIN = 0.d0
 
 !---quantize cloud fractions into bins to avoid excessive calculations for
 !---  nearly identical maximally overlapping cloud fractions.
@@ -866,8 +877,8 @@
 !---finished selection of max-overlap groups
 
 !---simplify groups if no clouds with NCLDF > NG_BRK
-      GBOT(:) = 0
-      GTOP(:) = 0
+      GBOT = 0
+      GTOP = 0
       if (NRG .eq. 0) then
         NRG = 1
         GBOT(1) = 1
@@ -885,7 +896,7 @@
       endif
 !---for each max-overlap group calculate number of unique cloud fractions
       do N = 1,NRG
-        NSAME(:) = 0
+        NSAME = 0
         GCMX(N) = 0
         do L = GBOT(N),GTOP(N)
           if (NCLDF(L) .gt. 0) then
@@ -962,9 +973,12 @@
       logical L_CLR1,L_CLR2  ,LSKIP   ,LGR_CLR(10)
 !-----------------------------------------------------------------------
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at ICA_ALL in module cldj_sub_mod.F90'
+      WCOL = 0.d0
+      OCOL = 0.d0
 
-      CLTOT(:) = 0.d0
+      CLTOT = 0.d0
 
         CF0(1) = 0.d0
       do L = 1,CBINU
@@ -1094,9 +1108,11 @@
       integer II, IG, G, L
 !-----------------------------------------------------------------------
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at ICA_III in module cldj_sub_mod.F90'
+      TTCOL = 0.d0
 
-      TTCOL(:) = 0.d0
+      TTCOL = 0.d0
       II = max(1, min(NICA,III))
       do G = 1,NRG
           IG = mod(II-1, GNR(G)) + 1
@@ -1134,12 +1150,17 @@
       real*8, parameter:: OD_QUAD(4) =[0.5d0, 4.0d0, 30.d0, 1.d9]
 !-----------------------------------------------------------------------
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at ICA_QUD in module cldj_sub_mod.F90'
+      ISORT = 0
+      NQ1   = 0
+      NQ2   = 0
+      NDXQS = 0
 
-      ISORT(:) = 0
-      WTQCA(:)  = 0.d0
-      NDXQS(:) = 0
-      OCOLS(:) = 0.d0
+      ISORT = 0
+      WTQCA = 0.d0
+      NDXQS = 0
+      OCOLS = 0.d0
 
 !---sort all the Indep Column Atmos (ICAs) in order of increasing column OD
 !--- ISORT is the key, giving the ICA number from smallest to largest column OD
@@ -1208,7 +1229,10 @@
       real*8 :: RA
 !-----------------------------------------------------------------------
 
+      ! initialize location and outputs for safety
       thisloc = ' -> at HEAPSORT_A in module cldj_sub_mod.F90'
+      AX = 0.d0
+      IX = 0
 
       do I = 1,N
         IX(I) = I

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -174,7 +174,8 @@
 !---CLOUD_JX:   different cloud schemes
 !-----------------------------------------------------------------------
       if (CLDFLAG.lt.1 .or. CLDFLAG.gt.8)then
-         call CLOUDJ_ERROR('>>>stop, incorrect cloud index', thisloc, rc)
+         call CLOUDJ_ERROR('Incorrect cloud index: must be between 1 and 8'// &
+              ' except 4', thisloc, rc)
       endif
 
 !--------------------CLDFLAG =  1, 2, 3---------------------------------
@@ -221,6 +222,10 @@
          call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,       &
                   DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,       &
                   NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK, RC)
+         if ( rc /= CLDJ_SUCCESS ) then
+            call CLOUDJ_ERROR( 'Error calling PHOTO_JX', thisLoc, rc )
+            return
+         endif
          if (.not.LDARK) then
             JCOUNT = JCOUNT + 1
          endif
@@ -263,11 +268,21 @@
 !-------------------------------------------------------------------------
          call ICA_NR(LPRTJ0,CLDX,CLT,IWPX,LWPX,ZZZ, CLDIW,LTOP,CBIN_,ICA_, &
              CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,RC)
+         if ( rc /= CLDJ_SUCCESS ) then
+            call CLOUDJ_ERROR( 'Error generating max-ran cloud overlap groups', &
+                 thisLoc, rc )
+            return
+         endif
 
 !---call ICA_ALL to generate the weight and cloud total OD of each ICA
 !-------------------------------------------------------------------------
          call ICA_ALL(LPRTJ0,CLDX,CLT,LTOP,CBIN_,ICA_, CFBIN,     &
             CLDCOR,NCLDF,GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL,RC)
+         if ( rc /= CLDJ_SUCCESS ) then
+            call CLOUDJ_ERROR( 'Error generating weight and cloud total OD', &
+                 thisLoc, rc )
+            return
+         endif
 
          if(LPRTJ0) then
             write(6,*) ' cloud-J v7.7  internal print:  #ICAs = ',NICA
@@ -276,7 +291,7 @@
 !-----------------------------------------------------------------------
 ! 4 = average direct beam over all ICAs  DISCONTINUED
          if (CLDFLAG .eq. 4) then
-            call CLOUDJ_ERROR(' CLD FLAG = 4 not allowed', thisloc, rc)
+            call CLOUDJ_ERROR('CLD FLAG = 4 not supported', thisloc, rc)
          endif
 
 !-----------------------------------------------------------------------
@@ -301,6 +316,10 @@
 
                call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR, &
                              GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
+               if ( rc /= CLDJ_SUCCESS ) then
+                  call CLOUDJ_ERROR( 'Error using cloud flag 5', thisLoc, rc )
+                  return
+               endif
 
 !---zero out cloud water paths which are not in the selected random ICA
                do L = 1, LTOP
@@ -326,6 +345,10 @@
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                      DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,        &
                      NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
+               if ( rc /= CLDJ_SUCCESS ) then
+                  call CLOUDJ_ERROR( 'Error using cloud flag 5', thisLoc, rc )
+                  return
+               endif
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
                endif
@@ -356,6 +379,10 @@
 
             call ICA_QUD(WCOL,OCOL,ICA_,NQD_,NICA, &
                          WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
+            if ( rc /= CLDJ_SUCCESS ) then
+               call CLOUDJ_ERROR( 'Error using cloud flag 6', thisLoc, rc )
+               return
+            endif
 
             if (LPRTJ0) then
                write(6,'(a)') ' quadrature QCAs(mid-pt): wt/range/index/OD'
@@ -372,6 +399,10 @@
 
                   call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR,  &
                                 GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
+                  if ( rc /= CLDJ_SUCCESS ) then
+                     call CLOUDJ_ERROR( 'Error using cloud flag 6', thisLoc, rc )
+                     return
+                  endif
 
 !---zero out cloud water paths which are not in the selected QCA
                   do L = 1, LTOP
@@ -388,6 +419,10 @@
                   call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH, &
                    DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,     &
                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK, RC)
+                  if ( rc /= CLDJ_SUCCESS ) then
+                     call CLOUDJ_ERROR( 'Error using cloud flag 6', thisLoc, rc )
+                     return
+                  endif
                   if (.not.LDARK) then
                      JCOUNT = JCOUNT + 1
                   endif
@@ -419,6 +454,10 @@
 
             call ICA_QUD(WCOL,OCOL,ICA_,NQD_,NICA, &
                          WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
+         if ( rc /= CLDJ_SUCCESS ) then
+            call CLOUDJ_ERROR( 'Error using cloud flag 7', thisLoc, rc )
+            return
+         endif
 
             if (LPRTJ0) then
                write(6,'(a)') ' quadrature QCAs(avg-cld): wt/range/index/OD'
@@ -437,6 +476,10 @@
 
                         call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR, &
                                       GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
+                        if ( rc /= CLDJ_SUCCESS ) then
+                           call CLOUDJ_ERROR( 'Error using cloud flag 7', thisLoc, rc )
+                           return
+                        endif
 
                         if (LPRTJ0) then
                            write(6,'(a,3i5,2f8.4,f9.3)') &
@@ -468,9 +511,14 @@
                      endif
 
 !-----------------------------------------------------------------------
-               call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
-                    DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
-                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
+                     call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
+                          DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
+                          NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
+                     if ( rc /= CLDJ_SUCCESS ) then
+                        call CLOUDJ_ERROR( 'Error using cloud flag 7', thisLoc, rc )
+                        return
+                     endif
+               
                      if (.not.LDARK) then
                         JCOUNT = JCOUNT + 1
                      endif
@@ -510,6 +558,10 @@
             do I = 1, NICA
                call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR,  &
                              GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
+               if ( rc /= CLDJ_SUCCESS ) then
+                  call CLOUDJ_ERROR( 'Error using cloud flag 8', thisLoc, rc )
+                  return
+               endif
 !---zero out cloud water paths which are not in the selected random ICA
                do L = 1, LTOP
                   LWPX(L) = LWP(L)
@@ -525,6 +577,11 @@
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                     DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
                     NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
+               if ( rc /= CLDJ_SUCCESS ) then
+                  call CLOUDJ_ERROR( 'Error using cloud flag 8', thisLoc, rc )
+                  return
+               endif
+               
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
                endif
@@ -1182,6 +1239,10 @@
         OCOLS(1) = OCOL(1)
       else
         call HEAPSORT_A (NICA,OCOL,OCOLS,ISORT,ICA_,RC)
+        if ( rc /= CLDJ_SUCCESS ) then
+           call CLOUDJ_ERROR( 'Error sorting ICAs', thisLoc, rc )
+           return
+        endif
       endif
         OCDFS(1) = WCOL(ISORT(1))
       do I = 2,NICA

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -90,7 +90,7 @@
 !     = 2 = ice cloud only
 !     = 3 = liquid+ice cloud mix
 !-----------------------------------------------------------------------
-      implicit none
+
 !---calling sequence variables
       integer, intent(in)                    :: L1U
       integer, intent(in)                    :: ANU
@@ -581,7 +581,6 @@
 !   GFNR(G=1:NRG,1:GNR(G)) = cloud fraction quantum no (value = 0 to NCBIN)
 !          Stores the specific cloud fractions counted in GNR.
 !-----------------------------------------------------------------------
-      implicit none
 
 !---Cloud Cover parameters (in cldj_cmn_mod.f90)
 !      integer, parameter ::  NQD_  = 4
@@ -945,7 +944,7 @@
 !---See JL Neu, MJ Prather, JE Penner (2007), Global atmospheric chemistry:
 !      Integrating over fractional cloud cover,J. Geophys. Res., 112, D11306,
 !       doi:10.1029/2006JD008007
-      implicit none
+
       logical, intent(in) :: LPRTJ0
       integer, intent(in) :: LTOP, CBINU, ICAU, NRG, NICA
       integer, intent(in), dimension(LTOP)  :: NCLDF
@@ -1082,7 +1081,7 @@
 !-----------------------------------------------------------------------
 !    see ICA_ALL, this subroutine picks out the ICA atmosphere #III
 !      and loads the REFF/WPs for a FAST_JX calculation.
-      implicit none
+
       logical, intent(in) :: LPRTJ0
       integer, intent(in) :: LTOP, CBINU, NRG, NICA, III
       integer, intent(in), dimension(LTOP)  :: NCLDF
@@ -1120,7 +1119,7 @@
 !---Create the Cumulative Prob Fn and select the mid-point ICA for each group
 !---The Quad atmospheres have weights WTQCA
 !-----------------------------------------------------------------------
-      implicit none
+
       integer, intent(in)        :: ICAU,NQDU,NICA
       real*8,  intent(in), dimension(ICAU)      :: WCOL,OCOL
 
@@ -1199,7 +1198,7 @@
 !           A(IX(J)) ==> AX(J), s.t. IX(1) = orig location of smallest A
 !                           and IX(N) = original loc. of largest A
 !-----------------------------------------------------------------------
-      implicit none
+
       integer, intent(in)  :: N, ND
       real*8, dimension(ND),intent(in)  :: A
       real*8, dimension(ND),intent(out) :: AX

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -1178,7 +1178,6 @@
       rc = CLDJ_SUCCESS
       TTCOL = 0.d0
 
-      TTCOL = 0.d0
       II = max(1, min(NICA,III))
       do G = 1,NRG
           IG = mod(II-1, GNR(G)) + 1

--- a/src/Interfaces/Standalone/CJ77.F90
+++ b/src/Interfaces/Standalone/CJ77.F90
@@ -13,6 +13,7 @@
       program standalone
 
       USE CLDJ_CMN_MOD
+      USE CLDJ_ERROR_MOD
       USE CLDJ_INIT_MOD
       USE CLDJ_FJX_SUB_MOD
       USE CLDJ_SUB_MOD, ONLY : CLOUD_JX
@@ -21,7 +22,7 @@
       implicit none
 !---------------key params in/out of CLOUD_J-------------------------
       logical                    :: LPRTJ, LDARK
-      integer                    :: IRAN
+      integer                    :: IRAN, RC
       integer                    :: JVNU,ANU,L1U
       integer                    :: NICA,JCOUNT
       real*8                     :: U0,SZA,SOLF
@@ -60,6 +61,7 @@
 
       write(6,'(a)') '>>>begin Cloud-J v7.7 Standalone'
 
+      RC = CLDJ_SUCCESS
       NLEVELS = 57
       ANU = AN_
       JVNU = JVN_
@@ -67,7 +69,7 @@
       amIRoot = .true.
 !---read in & store all fast-JX data:   single call at set up
 !-----------------------------------------------------------------------      
-      call INIT_CLDJ (amIRoot,'./tables/',NLEVELS,LWEPAR,TITLJXX,JVNU,NJXX)
+      call INIT_CLDJ (amIRoot,'./tables/',NLEVELS,LWEPAR,TITLJXX,JVNU,NJXX,RC)
 !-----------------------------------------------------------------------
 
 !--P, T, Cld & Aersl profiles, simple test input case
@@ -109,7 +111,7 @@
         enddo
 !---sets climatologies for O3, T, D & Z
 !-----------------------------------------------------------------------
-      call ACLIM_FJX (YLAT,MONTH,PPP, TTT,O3,CH4, L1_)
+      call ACLIM_FJX (YLAT,MONTH,PPP, TTT,O3,CH4, L1_, RC)
 !-----------------------------------------------------------------------
       do L = 1,L_
 !!!       TTT(L) = TI(L)  keep climatology T's and O3's
@@ -130,7 +132,7 @@
        OOO(L) = DDD(L)*O3(L)*1.d-6
        CCC(L) = DDD(L)*CH4(L)*1.d-9
 !-----------------------------------------------------------------------
-!       call ACLIM_RH (PL, TL, QL, HHH, L1U)
+!       call ACLIM_RH (PL, TL, QL, HHH, L1U, RC)
 !-----------------------------------------------------------------------
 ! quick fix Rel Humidity
        HHH(:) = 0.50d0
@@ -234,7 +236,7 @@
       if (LPRTJ) then
           write(6,'(a,f8.3,3f8.5)')'SZA SOLF U0 albedo' &
                 ,SZA,SOLF,U0,RFL(5,18)
-        call JP_ATM0(PPP,TTT,DDD,OOO,ZZZ, L_)
+        call JP_ATM0(PPP,TTT,DDD,OOO,ZZZ, L_, RC)
           write(6,*) ' wvl  albedo u1:u4 & u0'
         do K=1,NS2
           write(6,'(i5,f8.1,5f8.4)') K,WL(K), (RFL(J,K), J=1,5)
@@ -250,7 +252,7 @@
        call CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,       &
                RRR,OOO,CCC,  LWP,IWP,REFFL,REFFI, CLF,CLDCOR,CLDIW,    &
                AERSP,NDXAER,L1U,ANU,JVNU, VALJXX,SKPERD,SWMSQ,OD18,    &
-               IRAN,NICA, JCOUNT,LDARK,WTQCA)
+               IRAN,NICA, JCOUNT,LDARK,WTQCA,RC)
 !=======================================================================
 
 

--- a/src/Interfaces/Standalone/CJ77.F90
+++ b/src/Interfaces/Standalone/CJ77.F90
@@ -53,6 +53,7 @@
       integer LTOP, NJXX,JP04,JP09, NLEVELS
       character*6,  dimension(JVN_)  ::  TITLJXX
       character*11, dimension(4)     ::  TITJX
+      character*64                   ::  thisloc
       real*8 VJOSA(L2_,2),VJSTD(L2_,2)
       logical :: amIRoot
 
@@ -67,9 +68,13 @@
       JVNU = JVN_
       L1U = L1_
       amIRoot = .true.
+      thisloc = 'standalone program in CJ77.F90'
 !---read in & store all fast-JX data:   single call at set up
 !-----------------------------------------------------------------------      
       call INIT_CLDJ (amIRoot,'./tables/',NLEVELS,LWEPAR,TITLJXX,JVNU,NJXX,RC)
+      if ( RC /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR_STOP( 'Failure in INIT_CLDJ', thisloc )
+      endif
 !-----------------------------------------------------------------------
 
 !--P, T, Cld & Aersl profiles, simple test input case
@@ -112,6 +117,9 @@
 !---sets climatologies for O3, T, D & Z
 !-----------------------------------------------------------------------
       call ACLIM_FJX (YLAT,MONTH,PPP, TTT,O3,CH4, L1_, RC)
+      if ( RC /= CLDJ_SUCCESS ) then
+         call CLOUDJ_ERROR_STOP( 'Failure in ACLIM_FJX', thisloc )
+      endif
 !-----------------------------------------------------------------------
       do L = 1,L_
 !!!       TTT(L) = TI(L)  keep climatology T's and O3's
@@ -133,6 +141,9 @@
        CCC(L) = DDD(L)*CH4(L)*1.d-9
 !-----------------------------------------------------------------------
 !       call ACLIM_RH (PL, TL, QL, HHH, L1U, RC)
+!       if ( RC /= CLDJ_SUCCESS ) then
+!          call CLOUDJ_ERROR_STOP( 'Failure in ACLIM_RH', thisloc )
+!       endif
 !-----------------------------------------------------------------------
 ! quick fix Rel Humidity
        HHH(:) = 0.50d0
@@ -237,6 +248,9 @@
           write(6,'(a,f8.3,3f8.5)')'SZA SOLF U0 albedo' &
                 ,SZA,SOLF,U0,RFL(5,18)
         call JP_ATM0(PPP,TTT,DDD,OOO,ZZZ, L_, RC)
+        if ( RC /= CLDJ_SUCCESS ) then
+           call CLOUDJ_ERROR_STOP( 'Failure in JP_ATM0', thisloc )
+        endif
           write(6,*) ' wvl  albedo u1:u4 & u0'
         do K=1,NS2
           write(6,'(i5,f8.1,5f8.4)') K,WL(K), (RFL(J,K), J=1,5)
@@ -253,6 +267,9 @@
                RRR,OOO,CCC,  LWP,IWP,REFFL,REFFI, CLF,CLDCOR,CLDIW,    &
                AERSP,NDXAER,L1U,ANU,JVNU, VALJXX,SKPERD,SWMSQ,OD18,    &
                IRAN,NICA, JCOUNT,LDARK,WTQCA,RC)
+       if ( RC /= CLDJ_SUCCESS ) then
+          call CLOUDJ_ERROR_STOP( 'Failure in CLOUD_JX', thisloc )
+       endif
 !=======================================================================
 
 

--- a/tools/AddXs/FJ_Add_XNO3-v76.f
+++ b/tools/AddXs/FJ_Add_XNO3-v76.f
@@ -346,7 +346,7 @@ C---RAYLEIGH+RAMAN CROSS-SECTION (INCLUDE FOR ALL WAVELENGTHS)
 
 
       subroutine X_NO3 (WWX,TT, XXWTa,XXWTb,INIT,TITLNEW)
-      implicit none
+
       real*8, intent(in) :: WWX, TT
       integer, intent(inout) :: INIT
       real*8, intent(out) :: XXWTa,XXWTb

--- a/tools/AddXs/FJ_Add_XO3-v76.f
+++ b/tools/AddXs/FJ_Add_XO3-v76.f
@@ -328,7 +328,7 @@ c   XNEW = cross section (cm2) as a function of WW and XT (and XP, XM)
 c   INIT = initialization:
 c     if INIT.eq.0 .then reads in any tables and sets Xsect name to TITLNEW
 c-----------------------------------------------------------------------
-      implicit none
+
       real*8, intent(in) :: WW,XT
       real*8, intent(out) :: XNEW
       integer, intent(in) :: INIT
@@ -380,7 +380,7 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       subroutine Q_O3 (INIT, WW,XT,QNEW, TITLNEW,TITLTBL)
 c-----------------------------------------------------------------------
-      implicit none
+
       real*8, intent(in) :: WW,XT
       real*8, intent(out) :: QNEW
       integer, intent(inout) :: INIT

--- a/tools/AddXs/FJ_watts.f
+++ b/tools/AddXs/FJ_watts.f
@@ -1,4 +1,4 @@
-ï»¿c-------FJ_index11d.f    modern code for integrating over REFR INDEX, Rayleigh, YPar & fluxes
+c-------FJ_index11d.f    modern code for integrating over REFR INDEX, Rayleigh, YPar & fluxes
 !           uses both photons and Watts to do weighting  Example = water liqu & ice
 !           starts with pratmo full 77+SR bins and then generates the Solar-J bins (18+9)
 
@@ -474,7 +474,7 @@ c        Agricultural and Forest Meteorology 9:191-216.
 c      McCree, Keith J. (1972b). Agric. & Forest Meteorology 10:443-453.
 c---PAR in PAR is normally quantified as Âµmol photons/m2/s =? ÂµE/m2/s
 c        photosynthetic photon flux (area) density, or PPFD.
-      implicit none
+
       real*8 YPAR
       real*8, intent(in) :: WAVE
       integer IWW
@@ -1486,8 +1486,6 @@ C
 C     Note: You may need to remove the underscores from function names if
 C     using the g77 compiler.
 
-      IMPLICIT NONE
-
       REAL f                    ! [GHz]  Frequency (valid from 0 to 1000 GHz)
       REAL T                    ! [°C]   Temperature
       COMPLEX eps_swd_l91sd     !        Dielectric constant
@@ -1520,8 +1518,6 @@ C     and Manabe (Int. J. IR & mm Waves V.12 (7) July 1991).
 C
 C     Note: You may need to remove the underscores from function names if
 C     using the g77 compiler.
-
-      IMPLICIT NONE
 
       REAL f                    ! [GHz]  Frequency (valid from 0 to 1000 GHz)
       REAL T                    ! [°C]   Temperature


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR removes the legacy EXITC subroutine which stops the model upon error and replaces it with new subroutine CLOUDJ_ERROR which prints a message and returns RC flag equal to CLDJ_FAILURE. The RC flag is then passed up the calling stack to the parent model for model-specific error handling.

This PR also includes a few no diff structural improvements, including removing redundant instances of implicit none and using "(:)" when assigning all values of an array a constant value.

**This update requires updates in all parent models, including GEOS-Chem.**

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issues and PRs

https://github.com/geoschem/geos-chem/pull/2353 **(Merge required at the time as this PR)**
