### PR TITLE
Update the .zenodo.json file for auto-DOI generation upon release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,39 +1,31 @@
 {
     "access_right": "open",
     "creators": [
- 	{
-	    "affiliation": "Harvard University",
-            "name": "Elizabeth W. Lundgren"
+        {
+            "name": "Elizabeth Lundgren",
+            "affiliation": "Harvard University"
         },
-	{
-	    "affiliation": "University of California Irvine",
-	    "name": "Michael J. Prather"
-	},
-	{
-	    "affiliation": "Harvard University",
-	    "name": "Daniel J. Jacob"
-	}
+        {
+            "name": "Michael Prather",
+            "affiliation": "University of California, Irvine"
+        },
+        {
+            "name": "Daniel Jacob",
+            "affiliation": "Harvard University"
+        }
     ],
-    "contributors": [
-	{
-	    "affiliation": "Harvard University",
-	    "name": "Haipeng Lin"
-	},
- 	{
-	    "affiliation": "National Center for Atmospheric Research",
-	    "name": "Kyle Shores"
-	}
-    ],
-    "description": "Cloud-J multi-scattering radiative transfer model for solar radiation",
+    "description": "Cloud-J: A multi-scattering eight-stream radiative transfer model for solar radiation.",
     "keywords": [
-	"atmospheric-chemistry",
-	"atmospheric-composition",
-	"atmospheric-modeling",
-	"photolysis",
-	"radiative-transfer",
-	"atmospheric-computing",
-	"scientific-computing"
+        "radiative-transfer",
+        "clouds",
+        "geos-chem",
+        "atmospheric-chemistry",
+        "atmospheric-modeling",
+        "photolysis",
+        "atmospheric-composition",
+        "aerosols",
+        "earth-system-modeling"
     ],
-    "license": "gpl-3.0-license",
-    "upload_type": "software"
+    "upload_type": "software",
+    "license": "GPL-3.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file documents all notable changes to the Cloud-J repository since the init
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [7.7.2] - TBD
+### Added
+- `.zenodo.json` file for auto-creation of DOI upon issuing a new release
+
 ### Changed
 - Changed hard-coding LWEPAR in cldj_cmn_mod to be passed from parent model unless using standalone
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR updates the `.zenodo.json` file for DOI auto-generation upon version releases.  We have removed several non-conforming elements that had caused DOI generation to fail.

The `.zenodo.json` file in this PR was validated with the sandbox repo https://github.com/yantosca/zenodoplay.  It successfully generated this DOI record: https://zenodo.org/records/12727077

### Expected changes
A DOI will be automatically generated for each new Cloud-J version release. 

### Related Github Issues and PRs
N/A
