### PR TITLE
Improve speed by reducing error checks and safety initializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added gcc 14 to github action to build Cloud-J on mac
 
+### Changed
+- Minimized usage and checks of error codes to speed up the model
+
 ### Removed
 - Removed gcc 11 from github action to build Cloud-J on mac
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Removed gcc 11 from github action to build Cloud-J on mac
+- Removed safety initialization of outputs where assigning all values is obvious to improve performance
 
 ## [7.7.2] - 2024-07-12
 ### Added

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -222,11 +222,8 @@
       SWMSQ  = 0.d0
       OD18   = 0.d0
       LDARK  = .FALSE.
-
-      LU = L1U - 1
       FFXTAU = 0.d0
-      SWMSQ = 0.d0
-      OD18 = 0.d0
+      LU     = L1U - 1
 
 !---check for dark conditions SZA > 98.0 deg => tan ht = 63 km
 !                        or         99.0                 80 km
@@ -1320,12 +1317,8 @@
 !    ALSO limited to 4 Gauss points, only calculates mean field! (M=1)
 !-----------------------------------------------------------------------
 
-      ! initialize location and outputs for safetly
+      ! set location
       thisloc  = ' -> at MIESCT in module cldj_fjx_sub_mod.F90'
-      FJ  = 0.d0
-      FJT = 0.d0
-      FJB = 0.d0
-      FIB = 0.d0
 
       do I = 1,M_
          call LEGND0 (EMU(I),PM0,M2_)
@@ -1361,9 +1354,8 @@
       integer I
       real*8  DEN
 
-      ! initialize location and output for safety
+      ! set location
       thisloc = ' -> at LEGNDO in module cldj_fjx_sub_mod.F90'
-      PL = 0.d0
 
 !---Always does PL(2) = P[1]
       PL(1) = 1.d0
@@ -1966,12 +1958,8 @@
       integer I,J,K,L, NR
       real*8  FNR
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at OPTICL in module cldj_fjx_sub_mod.F90'
-      DDENS = 0.d0
-      QQEXT = 0.d0
-      SSALB = 0.d0
-      SSLEG = 0.d0
 
       K = 1   ! liquid water Mie clouds
       DDENS = DCC(K)
@@ -2015,12 +2003,8 @@
       integer I,J,K,L, NR
       real*8  FNR
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at OPTICI in module cldj_fjx_sub_mod.F90'
-      DDENS = 0.d0
-      QQEXT = 0.d0
-      SSALB = 0.d0
-      SSLEG = 0.d0
 
       if (TEFF .ge. 233.15d0) then
            K = 2  ! ice irreg (warm)
@@ -2071,11 +2055,8 @@
       integer I,J, KK
       real*8  XTINCT, REFF,RHO
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at OPTICS in module cldj_fjx_sub_mod.F90'
-      OPTD  = 0.d0
-      SSALB = 0.d0
-      SLEG  = 0.d0
 
       if (K .eq. 1) then
         KK = 4    ! background, 220K, 70 wt%
@@ -2120,11 +2101,8 @@
       integer I,J, KK
       real*8  XTINCT, REFF,RHO
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at OPTICG in module cldj_fjx_sub_mod.F90'
-      OPTD  = 0.d0
-      SSALB = 0.d0
-      SLEG  = 0.d0
 
       KK = max(1, min(NGG, K-1000))
       REFF = RGG(KK)
@@ -2160,11 +2138,8 @@
         integer I,J,JMIE
         real*8  XTINCT, REFF,RHO,WAVE, QAAX,SAAX,WAAX
 
-        ! initialize location and outputs for safety
+        ! set location
         thisloc = ' -> at OPTICA in module cldj_fjx_sub_mod.F90'
-        OPTD  = 0.d0
-        SSALB = 0.d0
-        SLEG  = 0.d0
 
 ! K=1&2 are the SSA values, not used here any more, make sure they are not
 !asked for.
@@ -2240,11 +2215,8 @@
       integer KR,J,L, JMIE
       real*8  R,FRH, GCOS, XTINCT, WAVE
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at OPTICM in module cldj_fjx_sub_mod.F90'
-      OPTD  = 0.d0
-      SSALB = 0.d0
-      SLEG  = 0.d0
 
 !---calculate fast-JX properties at the std 5 wavelengths:200-300-400-600-999nm
 !---extrapolate phase fn from first term (g)
@@ -2393,9 +2365,8 @@
       character(len=255)::  thisloc
       real*8  TFACT
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at X_interp in module cldj_fjx_sub_mod.F90'
-      XINT = 0.d0
 
       if (L123 .le. 1) then
            XINT = X1
@@ -2935,9 +2906,8 @@
       integer JTOTL,JX,L,LL
       real*8  ATAULN,ATAU0X,AJX,DTAU0X
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at EXTRAL1 in module cldj_fjx_sub_mod.F90'
-      JXTRA = 0
 
 !  need to divide DTAU600 into JX layers such that DTAU600/ATAU0 = ratio =
 !       1 + ATAU + ATAU^2 + ATAU^3 + ATAU^(JX-1)  = [ATAU^JX - 1]/[ATAU - 1]
@@ -3070,9 +3040,8 @@
       real*8, parameter :: CMF = 2.98897027277D-23 ! 18.d0 divided by
 ! Avogado number
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at FJX_CLIRAD_H2O in module cldj_fjx_sub_mod.F90'
-      TAUG_CLIRAD = 0.d0
 
 ! 0:0 will assign to bin 18 which is 0 for CLIRAD
       do L=1, nlayers
@@ -3149,9 +3118,8 @@
 
       real*8, parameter :: CMF = 2.98897027277D-23 ! 18.d0 divided by Avogado number
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at FJX_GGLLNL_H2O in module cldj_fjx_sub_mod.F90'
-      TAUG_LLNL = 0.d0
 
       ! 0:0 will assign to bin 18 which is 0 for CLIRAD
       do L=1, nlayers
@@ -3206,11 +3174,8 @@
       integer  K, L, M, N
       real*8   DDDL,DLOGP,F0,T0,H0,C0,PB,PC,XC
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at ACLIM_FJX in module cldj_fjx_sub_mod.F90'
-      TTT = 0.d0
-      O3  = 0.d0
-      CH4 = 0.d0
 
 !  Select appropriate month
       M = max(1,min(12,MONTH))
@@ -3277,7 +3242,7 @@
       real*8  T, eps, es, qs
       integer  L
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at ACLIM_RH in module cldj_fjx_sub_mod.F90'
 
       eps=287.04d0/461.50d0
@@ -3318,10 +3283,8 @@
       integer  I, IGG, K, L, M, N
       real*8   R0,X0,RX0,PB,PC,XC,YN,REDGE(GGA_)
 
-      ! initialize location and outputs for safety
+      ! set location
       thisloc = ' -> at ACLIM_GEO in module cldj_fjx_sub_mod.F90'
-      AERS = 0.d0
-      NAER = 0
 
 !  Select appropriate month
       M = max(1, min(12, MONTH))

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -167,7 +167,7 @@
       real*8,  intent(out), dimension(6)       :: SWMSQ  ! cloud-j output
       real*8,  intent(out), dimension(L1U)     :: OD18   ! cloud-j output
       logical, intent(out)                     :: LDARK  ! cloud-j output
-      integer, intent(out)                     :: RC     ! cloud-j output
+      integer, intent(inout)                   :: RC     ! cloud-j output
 
 !-----------------------------------------------------------------------
       character(len=255)  ::  thisloc, errmsg
@@ -217,7 +217,6 @@
 
       ! Initialize location and outputs
       thisloc = ' -> at PHOTO_JX in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       VALJXX = 0.d0
       SKPERD = 0.d0
       SWMSQ  = 0.d0
@@ -272,19 +271,13 @@
 !   indep of wavelength (refracted path assumes visible index of refraction)
 !-----------------------------------------------------------------------
       if (ATM0 .eq. 0) then
-         call SPHERE1F (U0,RAD,ZZJ,ZZHT,AMF, L1U,RC)  ! flat Earth, AMF=1/u0
+         call SPHERE1F (U0,RAD,ZZJ,ZZHT,AMF, L1U)  ! flat Earth, AMF=1/u0
       elseif (ATM0 .eq. 1) then
-         call SPHERE1N (U0,RAD,ZZJ,ZZHT,AMF, L1U,RC)  ! spherical straight-line
+         call SPHERE1N (U0,RAD,ZZJ,ZZHT,AMF, L1U)  ! spherical straight-line
                                                    ! paths
       else     ! 2 or 3
-         call SPHERE1R (U0,RAD,ZZJ,ZZHT,AMF, L1U,RC)  ! spherical w/refraction
+         call SPHERE1R (U0,RAD,ZZJ,ZZHT,AMF, L1U)  ! spherical w/refraction
       endif
-      if ( rc /= CLDJ_SUCCESS ) then
-         call CLOUDJ_ERROR( 'Error calculating spherical weighting functions', &
-              thisloc, rc )
-         return
-      endif
-
 
 !-----------------------------------------------------------------------
 
@@ -294,10 +287,10 @@
 !SJ! needed in Solar-J version
 !      if (W_r .ne. 0)then
 !         if (W_r .eq. W_rrtmg)  call RRTMG_SW_INP(IYEAR,L1U,PPJ,ZZJ,DDJ,&
-!                                                  TTJ,HHJ,OOJ,CCJ,TAUG_RRTMG,RC)
+!                                                  TTJ,HHJ,OOJ,CCJ,TAUG_RRTMG)
 !         if (W_r .eq. W_Clirad) call FJX_CLIRAD_H2O(L1U,PPJ,TTJ,HHJ,&
-!                                                    TAUG_CLIRAD,RC)
-!         if (W_r .eq. W_LLNL)   call FJX_GGLLNL_H2O(L1U,PPJ,TTJ,HHJ,TAUG_LLNL,RC)
+!                                                    TAUG_CLIRAD)
+!         if (W_r .eq. W_LLNL)   call FJX_GGLLNL_H2O(L1U,PPJ,TTJ,HHJ,TAUG_LLNL)
 !         write(6,'(a,I5,a,I5,a,I5,a,I5)')'W_r=    ', W_r, 'W_rrtmg=', &
 !               W_rrtmg, 'W_clirad=', W_clirad, 'W_LLNL=', W_LLNL
 
@@ -342,12 +335,7 @@
             RE_LIQ = REFFL(L)
             TE_ICE = TTT(L)
 
-            call OPTICL (RE_LIQ,TE_ICE, DDENS, QQEXT,SSALB,SSLEG,RC)
-            if ( rc /= CLDJ_SUCCESS ) then
-               errmsg = 'Error computing optics of liquid water cloud'
-               call CLOUDJ_ERROR( errmsg, thisloc, rc )
-               return
-            endif
+            call OPTICL (RE_LIQ,TE_ICE, DDENS, QQEXT,SSALB,SSLEG)
 
 !---extinction K(m2/g) = 3/4 * Q / [Reff(micron) * density(g/cm3)]
             do K = 1,S_
@@ -375,12 +363,7 @@
             RE_ICE = REFFI(L)
             TE_ICE = TTT(L)
 
-            call OPTICI (RE_ICE,TE_ICE, DDENS, QQEXT,SSALB,SSLEG,RC)
-            if ( rc /= CLDJ_SUCCESS ) then
-               errmsg = 'Error computing optics of ice water cloud'
-               call CLOUDJ_ERROR( errmsg, thisloc, rc )
-               return
-            endif
+            call OPTICI (RE_ICE,TE_ICE, DDENS, QQEXT,SSALB,SSLEG)
 
       !---extinction K(m2/g) = 3/4 * Q / [Reff(micron) * density(g/cm3)]
             do K = 1,S_
@@ -413,11 +396,6 @@
                if (PATH .gt. 0.d0) then
 
                   call OPTICS (OPTX,SSALB,SSLEG, PATH,NAER,RC)
-                  if ( rc /= CLDJ_SUCCESS ) then
-                     errmsg = 'Error computing optics of strat sulfate aerosol cloud'
-                     call CLOUDJ_ERROR( errmsg, thisloc, rc )
-                     return
-                  endif
 
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
@@ -436,6 +414,7 @@
                endif
             endif
          enddo
+
 !---GEOMIP enhanced Strat Sulfate Aerosols: use index = 1001 to 1000+NGG
          do M = 1,ANU
             NAER = NDXAER(L,M)
@@ -444,13 +423,7 @@
                PATH = AERSP(L,M)
                if (PATH .gt. 0.d0) then
 
-                  call OPTICG (OPTX,SSALB,SSLEG, PATH,NAER,RC)
-                  if ( rc /= CLDJ_SUCCESS ) then
-                     errmsg = 'Error computing optics of GEOMIP enhanced '// &
-                          'strat sulfate aerosols'
-                     call CLOUDJ_ERROR( errmsg, thisloc, rc )
-                     return
-                  endif
+                  call OPTICG (OPTX,SSALB,SSLEG, PATH,NAER)
 
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
@@ -481,11 +454,6 @@
             if (PATH .gt. 0.d0) then
                if (NAER.gt.2 .and. NAER.lt.1000) then
                   call OPTICA (OPTX,SSALB,SSLEG, PATH,RH, NAER,RC)
-                  if ( rc /= CLDJ_SUCCESS ) then
-                     errmsg = 'Error computing optics of aerosols'
-                     call CLOUDJ_ERROR( errmsg, thisloc, rc )
-                     return
-                  endif
 
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
@@ -511,11 +479,6 @@
                if (NAER .lt. 0) then
 
                   call OPTICM (OPTX,SSALB,SSLEG, PATH,RH, -NAER,RC)
-                  if ( rc /= CLDJ_SUCCESS ) then
-                     errmsg = 'Error computing optics of U Michigan aerosols'
-                     call CLOUDJ_ERROR( errmsg, thisloc, rc )
-                     return
-                  endif
 
                   do K = 1,S_
                      OD(K,L)  = OD(K,L)  + OPTX(K)
@@ -539,18 +502,10 @@
          do K = 1,W_
             TTTX = TTJ(L)
             call X_interp (TTTX,XQO2, TQQ(1,1),QO2(K,1), TQQ(2,1), &
-                           QO2(K,2),  TQQ(3,1),QO2(K,3), LQQ(1), RC)
-            if ( rc /= CLDJ_SUCCESS ) then
-               call CLOUDJ_ERROR( 'Error in X_interp: 1', thisloc, rc )
-               return
-            endif
+                           QO2(K,2),  TQQ(3,1),QO2(K,3), LQQ(1) )
 
             call X_interp (TTTX,XQO3, TQQ(1,2),QO3(K,1), TQQ(2,2), &
-                 QO3(K,2),  TQQ(3,2),QO3(K,3), LQQ(2), RC)
-            if ( rc /= CLDJ_SUCCESS ) then
-               call CLOUDJ_ERROR( 'Error in X_interp: 2', thisloc, rc )
-               return
-            endif
+                 QO3(K,2),  TQQ(3,2),QO3(K,3), LQQ(2) )
 
             ODABS = XQO3*OOJ(L) + XQO2*DDJ(L)*0.20948d0
             OD(K,L)  = OD(K,L)  + ODABS
@@ -625,13 +580,7 @@
 
 !---Using aerosol+cloud OD/layer in visible (600 nm) calculate how to add layers
 !-----------------------------------------------------------------------
-      call EXTRAL1(OD600,L1U,N_,ATAU,ATAU0, JXTRA, RC)
-      if ( rc /= CLDJ_SUCCESS ) then
-         errmsg = 'Error using aerosol+cloud OD/layer in visible (600 nm) to '//&
-              'calculate how to add layers'
-         call CLOUDJ_ERROR( errmsg, thisloc, rc )
-         return
-      endif
+      call EXTRAL1(OD600,L1U,N_,ATAU,ATAU0, JXTRA)
 
 !-----------------------------------------------------------------------
 !---complete calculation of actinic and net fluxes for all L & wavelengths
@@ -639,13 +588,6 @@
 !-----------------------------------------------------------------------
       call OPMIE (DTAUX,POMEGAX,U0,RFL,AMF,AMG,JXTRA, &
               AVGF,FJTOP,FJBOT,FIBOT,FSBOT,FJFLX,FLXD,FLXD0, LDOKR,LU,RC)
-      if ( rc /= CLDJ_SUCCESS ) then
-         errmsg = 'Error computing actinic and net fluxes for all L '// &
-              'and wavelengths'
-         call CLOUDJ_ERROR( errmsg, thisloc, rc )
-         return
-      endif
-
 
 !-----------------------------------------------------------------------
       FFF   = 0.d0
@@ -684,10 +626,6 @@
 
 !-----------------------------------------------------------------------
       call JRATET(PPJ,TTJ,FFF, VALJXX, LU,NJXU,RC)
-      if ( rc /= CLDJ_SUCCESS ) then
-         call CLOUDJ_ERROR( 'Error computing J-values', thisloc, rc )
-         return
-      endif
 
 !-----------------------------------------------------------------------
 
@@ -786,11 +724,7 @@
             enddo
          enddo
          write(6,'(a)') 'Fast-J  v7.6 ---PHOTO_JX internal print: Atmosphere--'
-         call JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU600,POMG600,JXTRA, LU,RC)
-         if ( rc /= CLDJ_SUCCESS ) then
-            call CLOUDJ_ERROR( 'Error calling JP_ATM', thisloc, rc )
-            return
-         endif
+         call JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU600,POMG600,JXTRA, LU)
 
 !SJ!         if (LRRTMG .or. LCLIRAD .or. LGGLLNL) then
 !SJ!            write(ParaSummary(26:200),'(a, 10f10.4)') &
@@ -936,6 +870,13 @@
        endif  ! end of CLOUDJ print
       endif   ! end of LPRTJ if
 
+      ! Error catch
+      if ( rc /= CLDJ_SUCCESS ) then
+         errmsg = 'Error in fast-jx core code within Cloud-J'
+         call CLOUDJ_ERROR( errmsg, thisloc, rc )
+         return
+      endif
+
       END SUBROUTINE PHOTO_JX
 
 
@@ -952,7 +893,7 @@
       real*8, intent(out) ::  FJACT(L1_,W_+W_r),FIBOT(5,W_+W_r)
       real*8, intent(out) ::  FJTOP(W_+W_r),FJBOT(W_+W_r),FSBOT(W_+W_r)
       real*8, intent(out) ::  FJFLX(L1_,W_+W_r),FLXD(L1_,W_+W_r),FLXD0(W_+W_r)
-      integer, intent(out) :: RC
+      integer, intent(inout) :: RC
 
       character(len=255) ::  thisloc
       integer JADDTO,L2LEV(L1_+1)
@@ -1045,7 +986,6 @@
 
       ! initialize
       thisloc = ' -> at OPMIE in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       FJACT = 0.d0
       FJTOP = 0.d0
       FIBOT = 0.d0
@@ -1303,11 +1243,7 @@
       enddo  ! k wavelength loop end
 
 !-----------------------------------------------------------------------
-       call MIESCT(FJ,FJTOP,FJBOT,FIBOT, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND,RC)
-      if ( rc /= CLDJ_SUCCESS ) then
-         call CLOUDJ_ERROR( 'Error in MIESCT', thisloc, rc )
-         return
-      endif
+       call MIESCT(FJ,FJTOP,FJBOT,FIBOT, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND)
 
 !-----------------------------------------------------------------------
 
@@ -1356,7 +1292,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine MIESCT(FJ,FJT,FJB,FIB, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND,RC)
+      subroutine MIESCT(FJ,FJT,FJB,FIB, POMEGA,FZ,ZTAU,FSBOT,RFL,U0,LDOKR,ND)
 !-----------------------------------------------------------------------
 
       integer, intent(in)  ::  LDOKR(W_+W_r),ND
@@ -1364,7 +1300,6 @@
                                ZTAU(N_,W_+W_r),RFL(5,W_+W_r),U0,FSBOT(W_+W_r)
       real*8,  intent(out) ::  FJ(N_,W_+W_r),FJT(W_+W_r)
       real*8,  intent(out) ::  FJB(W_+W_r),FIB(5,W_+W_r)
-      integer, intent(out) :: RC
 
       character(len=255)   ::  thisloc
       real*8  PM(M_,M2_),PM0(M2_)
@@ -1387,7 +1322,6 @@
 
       ! initialize location and outputs for safetly
       thisloc  = ' -> at MIESCT in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       FJ  = 0.d0
       FJT = 0.d0
       FJB = 0.d0
@@ -1409,11 +1343,7 @@
 
 !---BLKSLV now called with all the wavelength arrays (K=1:W_)
 
-      call BLKSLV(FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJT,FJB,FIB,LDOKR,ND,RC)
-      if ( rc /= CLDJ_SUCCESS ) then
-         call CLOUDJ_ERROR( 'Error in BLKSLV', thisloc, rc )
-         return
-      endif
+      call BLKSLV(FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJT,FJB,FIB,LDOKR,ND)
 
       END SUBROUTINE MIESCT
 
@@ -1448,7 +1378,7 @@
 
 !-----------------------------------------------------------------------
       subroutine BLKSLV &
-         (FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJTOP,FJBOT,FIBOT,LDOKR,ND,RC)
+         (FJ,POMEGA,FZ,ZTAU,FSBOT,RFL,PM,PM0,FJTOP,FJBOT,FIBOT,LDOKR,ND)
 !-----------------------------------------------------------------------
 !  Sets up and solves the block tri-diagonal system:
 !               A(I)*X(I-1) + B(I)*X(I) + C(I)*X(I+1) = H(I)
@@ -1462,7 +1392,6 @@
                               RFL(5,W_+W_r),FSBOT(W_+W_r)
       real*8, intent(out) ::  FJ(N_,W_+W_r),FJTOP(W_+W_r),FJBOT(W_+W_r), &
                               FIBOT(5,W_+W_r)
-      integer, intent(out) :: RC
 
       character(len=255)  ::  thisloc
       real*8, dimension(M_,N_,W_+W_r)    ::  A,C,H,   RR
@@ -1474,7 +1403,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at BLKSLV in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       FJ    = 0.d0
       FJTOP = 0.d0
       FJBOT = 0.d0
@@ -1484,11 +1412,7 @@
       if (LDOKR(K) .gt. 0) then
        call GEN_ID (POMEGA(1,1,K),FZ(1,K),ZTAU(1,K),FSBOT(K),RFL(1,K), &
              PM,PM0, B(1,1,1,K),CC(1,1,1,K),AA(1,1,1,K), &
-                     A(1,1,K),H(1,1,K),C(1,1,K), ND, RC)
-      if ( rc /= CLDJ_SUCCESS ) then
-         call CLOUDJ_ERROR( 'Error in GEN_ID', thisloc, rc )
-         return
-      endif
+                     A(1,1,K),H(1,1,K),C(1,1,K), ND)
       endif
       enddo
 
@@ -1749,7 +1673,7 @@
 
 !-----------------------------------------------------------------------
       subroutine GEN_ID(POMEGA,FZ,ZTAU,ZFLUX,RFL,PM,PM0 &
-                    ,B,CC,AA,A,H,C,  ND,RC)
+                    ,B,CC,AA,A,H,C,  ND)
 !-----------------------------------------------------------------------
 !  Generates coefficient matrices for the block tri-diagonal system:
 !               A(I)*X(I-1) + B(I)*X(I) + C(I)*X(I+1) = H(I)
@@ -1762,7 +1686,6 @@
 
       real*8, intent(out),dimension(M_,M_,N_) ::  B,AA,CC
       real*8, intent(out),dimension(M_,N_) ::  A,C,H
-      integer, intent(out) :: RC
 
       character(len=255)  ::  thisloc
       integer I, J, K, L1,L2,LL
@@ -1774,7 +1697,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at GEN_ID in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       B  = 0.d0
       AA = 0.d0
       CC = 0.d0
@@ -2025,7 +1947,7 @@
 !<<<<<begin fastJX subroutines called from PHOTO_JX or OPMIE<<<<<<<<<<<<
 
 !------------------------------------------------------------------------------
-      subroutine OPTICL (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG,RC)
+      subroutine OPTICL (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG)
 !------------------------------------------------------------------------------
 ! new for FJ v7.5  for LIQUID water clouds only  interpolate properties to R_eff
 ! every S-bin has its own optical properties
@@ -2039,7 +1961,6 @@
       real*8, intent(out)::    QQEXT(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
-      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer I,J,K,L, NR
@@ -2047,7 +1968,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICL in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       DDENS = 0.d0
       QQEXT = 0.d0
       SSALB = 0.d0
@@ -2076,7 +1996,7 @@
 
 
 !------------------------------------------------------------------------------
-      subroutine OPTICI (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG,RC)
+      subroutine OPTICI (REFF,TEFF, DDENS,QQEXT,SSALB,SSLEG)
 !------------------------------------------------------------------------------
 ! new for FJ v7.5, parallel with liquid water, but two types of ice-water
 ! phase functions from a single calculation of Mishchenko, other opticals
@@ -2090,7 +2010,6 @@
       real*8, intent(out)::    QQEXT(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)    ! single-scattering albedo
       real*8, intent(out)::    SSLEG(8,S_)  ! scatt phase fn (Leg coeffs)
-      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer I,J,K,L, NR
@@ -2098,7 +2017,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICI in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       DDENS = 0.d0
       QQEXT = 0.d0
       SSALB = 0.d0
@@ -2147,7 +2065,7 @@
       real*8, intent(out)::    OPTD(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
       real*8, intent(out)::    SLEG(8,S_) ! scatt phase fn (Leg coeffs)
-      integer, intent(out) :: RC
+      integer, intent(inout) :: RC
 
       character(len=255)::     thisloc
       integer I,J, KK
@@ -2155,7 +2073,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICS in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       OPTD  = 0.d0
       SSALB = 0.d0
       SLEG  = 0.d0
@@ -2186,7 +2103,7 @@
 
 
 !------------------------------------------------------------------------------
-      subroutine OPTICG (OPTD,SSALB,SLEG, PATH,K,RC)
+      subroutine OPTICG (OPTD,SSALB,SLEG, PATH,K)
 !------------------------------------------------------------------------------
 !---for the GEOMIP SSA (stratospheric sulfate aerosol) data sets
 ! K = 1001:1015 corresponds to R-eff = 0.02 0.04 0.08 0.10 ...  1.4 2.0 3.0
@@ -2198,7 +2115,6 @@
       real*8, intent(out)::    OPTD(S_)    ! optical depth of layer
       real*8, intent(out)::    SSALB(S_)   ! single-scattering albedo
       real*8, intent(out)::    SLEG(8,S_)  ! scatt phase fn (Leg coeffs)
-      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer I,J, KK
@@ -2206,7 +2122,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICG in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       OPTD  = 0.d0
       SSALB = 0.d0
       SLEG  = 0.d0
@@ -2239,7 +2154,7 @@
         real*8, intent(in)::     PATH        ! path (g/m2) of aerosol/cloud
         real*8, intent(in)::     RELH        ! relative humidity (0.00->1.00+)
         integer,intent(inout)::     K        ! index of cloud/aerosols
-        integer, intent(out) :: RC
+        integer, intent(inout) :: RC
 
         character(len=255) ::    thisloc
         integer I,J,JMIE
@@ -2247,7 +2162,6 @@
 
         ! initialize location and outputs for safety
         thisloc = ' -> at OPTICA in module cldj_fjx_sub_mod.F90'
-        rc = CLDJ_SUCCESS
         OPTD  = 0.d0
         SSALB = 0.d0
         SLEG  = 0.d0
@@ -2320,7 +2234,7 @@
       real*8, intent(in)::     PATH       ! path (g/m2) of aerosol/cloud
       real*8, intent(in)::     RELH       ! relative humidity (0.00->1.00)
       integer,intent(in)::     LL         ! index of cloud/aerosols
-      integer, intent(out) :: RC
+      integer, intent(inout) :: RC
 
       character(len=255) :: thisloc
       integer KR,J,L, JMIE
@@ -2328,7 +2242,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at OPTICM in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       OPTD  = 0.d0
       SSALB = 0.d0
       SLEG  = 0.d0
@@ -2387,7 +2300,7 @@
       real*8, intent(in)  ::  PPJ(LU+1),TTJ(LU+1)
       real*8, intent(inout)  ::  FFF(W_,LU)
       real*8, intent(out), dimension(LU,NJXU) ::  VALJL
-      integer, intent(out) :: RC
+      integer, intent(inout) :: RC
 
       character(len=255) :: thisloc
       real*8  VALJ(X_)
@@ -2397,7 +2310,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at JRATET in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       VALJL = 0.d0
 
       if (NJXU .lt. NJX) then
@@ -2429,25 +2341,13 @@
 !     for J=1:3  O2, O3(total), & O3(O1D)
         do K = 1,W_
            call X_interp (TT, QO2TOT, TQQ(1,1),QO2(K,1), TQQ(2,1), QO2(K,2), &
-                TQQ(3,1),QO2(K,3), LQQ(1), RC)
-           if ( rc /= CLDJ_SUCCESS ) then
-              call CLOUDJ_ERROR( 'Error in X_interp, J=1', thisloc, rc )
-              return
-           endif
+                TQQ(3,1),QO2(K,3), LQQ(1) )
            
            call X_interp (TT,QO3TOT, TQQ(1,2),QO3(K,1),TQQ(2,2),QO3(K,2), &
-                TQQ(3,2),QO3(K,3), LQQ(2), RC) 
-           if ( rc /= CLDJ_SUCCESS ) then
-              call CLOUDJ_ERROR( 'Error in X_interp, J=2 ', thisloc, rc )
-              return
-           endif
+                TQQ(3,2),QO3(K,3), LQQ(2) ) 
            
            call X_interp (TT,QO31DY, TQQ(1,3),Q1D(K,1),TQQ(2,3),Q1D(K,2), &
-                TQQ(3,3),Q1D(K,3), LQQ(3), RC)
-           if ( rc /= CLDJ_SUCCESS ) then
-              call CLOUDJ_ERROR( 'Error in X_interp, J=3', thisloc, rc )
-              return
-           endif
+                TQQ(3,3),Q1D(K,3), LQQ(3) )
 
           QO31D  = QO31DY*QO3TOT
           VALJ(1) = VALJ(1) + QO2TOT*FFF(K,L)
@@ -2460,19 +2360,11 @@
 !---also need to allow for Pressure interpolation if SQQ(J) = 'p'
             if (SQQ(J) .eq.'p') then
                call X_interp (PP,QQQT, TQQ(1,J),QQQ(K,1,J), &
-                    TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J), RC)
-               if ( rc /= CLDJ_SUCCESS ) then
-                  call CLOUDJ_ERROR( 'Error in X_interp when SQQ==p', thisloc, rc )
-                  return
-               endif
+                    TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J))
 
             else
               call X_interp (TT,QQQT, TQQ(1,J),QQQ(K,1,J), &
-                   TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J), RC)
-              if ( rc /= CLDJ_SUCCESS ) then
-                 call CLOUDJ_ERROR( 'Error in X_interp when SQQ/=p ', thisloc, rc )
-                 return
-              endif
+                   TQQ(2,J),QQQ(K,2,J), TQQ(3,J),QQQ(K,3,J), LQQ(J) )
 
             endif
               VALJ(J) = VALJ(J) + QQQT*FFF(K,L)
@@ -2489,7 +2381,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine X_interp (TINT,XINT, T1,X1, T2,X2, T3,X3, L123,RC)
+      subroutine X_interp (TINT,XINT, T1,X1, T2,X2, T3,X3, L123 )
 !-----------------------------------------------------------------------
 !  up-to-three-point linear interpolation function for X-sections
 !-----------------------------------------------------------------------
@@ -2497,14 +2389,12 @@
       real*8, intent(in)::  TINT,T1,T2,T3, X1,X2,X3
       integer,intent(in)::  L123
       real*8, intent(out)::  XINT
-      integer, intent(out) :: RC
 
       character(len=255)::  thisloc
       real*8  TFACT
 
       ! initialize location and outputs for safety
       thisloc = ' -> at X_interp in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       XINT = 0.d0
 
       if (L123 .le. 1) then
@@ -2526,7 +2416,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU6,POMEG6,JXTRA,LU,RC)
+      subroutine JP_ATM(PPJ,TTJ,DDJ,OOJ,ZZJ,DTAU6,POMEG6,JXTRA,LU)
 !-----------------------------------------------------------------------
 
 !-----------------------------------------------------------------------
@@ -2537,7 +2427,6 @@
       real*8, intent(in), dimension(LU+1) :: TTJ,DDJ,OOJ,DTAU6
       real*8, intent(in), dimension(8,LU+1) :: POMEG6
       integer,intent(in), dimension(LU+1) :: JXTRA
-      integer, intent(out) :: RC
 !-----------------------------------------------------------------------
       character(len=255)  ::  thisloc
       integer  I,J,K,L
@@ -2545,7 +2434,6 @@
 
       ! initialize
       thisloc = ' -> at JP_ATM in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
 
       write(6,'(4a)') '   L z(km)     p      T   ', &
        '    d(air)   d(O3)','  col(O2)  col(O3)     d-TAU   SS-alb', &
@@ -2573,7 +2461,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine JP_ATM0(PPJ,TTJ,DDJ,OOJ,ZZJ, LU,RC)
+      subroutine JP_ATM0(PPJ,TTJ,DDJ,OOJ,ZZJ, LU)
 !-----------------------------------------------------------------------
 
 !-----------------------------------------------------------------------
@@ -2583,14 +2471,12 @@
       integer,intent(in)                  :: LU
       real*8, intent(in), dimension(LU+2) :: PPJ,ZZJ
       real*8, intent(in), dimension(LU+1) :: TTJ,DDJ,OOJ
-      integer, intent(out) :: RC
 !-----------------------------------------------------------------------
       character(len=255)  ::  thisloc
       integer  I,J,K,L
       real*8   XCOLO2,XCOLO3,ZKM,DELZ,ZTOP
 
       thisloc = ' -> at JP_ATM0 in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
 
       write(6,'(4a)') '   L z(km)     p      T   ', &
        '    d(air)   d(O3)','  col(O2)  col(O3)     d-TAU   SS-alb', &
@@ -2616,7 +2502,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SPHERE1R (U0,RAD,ZHL,ZZHT,AMF, L1U,RC)
+      subroutine SPHERE1R (U0,RAD,ZHL,ZZHT,AMF, L1U)
 !-----------------------------------------------------------------------
 !  version 7.6  - SPHERE1N = drops the mid-layer (v6.2) for comp cost
 !     also 7.6  - SPHERE1R = adds refraction (complex ray tracing)
@@ -2648,7 +2534,6 @@
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
-      integer, intent(out) :: RC
 
       character(len=255)  ::   thisloc
       integer  L,L0, K,K0, LTOP
@@ -2660,7 +2545,6 @@
 
       ! initialize location and outputs for safety
       thisloc = " -> at SPHERE1R in module cldj_fjx_sub_mod.F90"
-      rc = CLDJ_SUCCESS
       AMF = 0.d0
 !-----------------------------------------------------------------------
 !  this versions sets a density scale ht of DDHT=8km, and a
@@ -2854,7 +2738,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SPHERE1N (U0,RAD,ZHL,ZZHT,AMF, L1U,RC)
+      subroutine SPHERE1N (U0,RAD,ZHL,ZZHT,AMF, L1U)
 !-----------------------------------------------------------------------
 !  version 7.6a  - SPHERE1N = drops the mid-layer (v6.2) for comp cost
 !     also 7.6b  - SPHERE1R = adds refraction (complex ray tracing)
@@ -2879,7 +2763,6 @@
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
-      integer, intent(out) :: RC
 
       character(len=255)  ::   thisloc
       integer  L, J, JUP, LTOP, K
@@ -2889,7 +2772,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at SPHERE1N in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       AMF = 0.d0
 
       LTOP = L1U
@@ -2972,7 +2854,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SPHERE1F (U0,RAD,ZHL,ZZHT,AMF, L1U,RC)
+      subroutine SPHERE1F (U0,RAD,ZHL,ZZHT,AMF, L1U)
 !-----------------------------------------------------------------------
 !     needed for testing flat-disk errors
 !  version 7.6a  - SPHERE1N = drops the mid-layer (v6.2) for comp cost
@@ -2994,7 +2876,6 @@
       integer, intent(in) ::   L1U
       real*8, intent(in)  ::   U0,RAD,ZHL(L1_+1),ZZHT
       real*8, intent(out) ::   AMF(L1_+1,L1_+1)
-      integer, intent(out) :: RC
 
       character(len=255)  ::   thisloc
       integer  L, J, LTOP
@@ -3002,7 +2883,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at SPHERE1F in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       AMF = 0.d0
 
       LTOP = L1U
@@ -3023,7 +2903,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine EXTRAL1(DTAU600,L1X,NX,ATAU,ATAU0, JXTRA,RC)
+      subroutine EXTRAL1(DTAU600,L1X,NX,ATAU,ATAU0, JXTRA)
 !-----------------------------------------------------------------------
 !     version 7.6 replaces v 6.2 and drops back to no mid-layer J(odd) points.
 !   Purpose:  reduce spurious negative heating at top of thick clouds.
@@ -3050,7 +2930,6 @@
       real*8,  intent(in) ::  DTAU600(L1X)     !cloud+3aerosol OD in each layer
       real*8,  intent(in) ::  ATAU,ATAU0
       integer, intent(out)::  JXTRA(L1X)    !number of sub-layers to be added
-      integer, intent(out) :: RC
 
       character(len=255)  ::  thisloc
       integer JTOTL,JX,L,LL
@@ -3058,7 +2937,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at EXTRAL1 in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       JXTRA = 0
 
 !  need to divide DTAU600 into JX layers such that DTAU600/ATAU0 = ratio =
@@ -3087,7 +2965,6 @@
             do LL = L,1,-1
                JXTRA(LL) = 0
             enddo
- !           call CloudJ_Error('STOP at EXTRAL', thisloc, rc) !not necessary, a warning is OK
             go to 10
          endif
       enddo
@@ -3097,7 +2974,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine SOLAR_JX(GMTIME,NDAY,YGRDJ,XGRDI, SZA,COSSZA,SOLFX,RC)
+      subroutine SOLAR_JX(GMTIME,NDAY,YGRDJ,XGRDI, SZA,COSSZA,SOLFX)
 !-----------------------------------------------------------------------
 ! >>>>>>>> warning tnot specific for SOLAR-J, is it old FAST_J call
 !     GMTIME = UT for when J-values are wanted
@@ -3113,14 +2990,12 @@
       real*8,  intent(in)  ::  GMTIME,YGRDJ,XGRDI
       integer, intent(in)  ::  NDAY
       real*8,  intent(out) ::  SZA,COSSZA,SOLFX
-      integer, intent(out) :: RC
 !
       character(len=255)   ::  thisloc
       real*8  LOCT
       real*8  SINDEC, SOLDEK, COSDEC, SINLAT, SOLLAT, COSLAT, COSZ
 
       thisloc = ' -> at SOLAR_JX in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
 
       SINDEC = 0.3978d0*sin(0.9863d0*(dble(NDAY)-80.d0)*CPI180)
       SOLDEK = asin(SINDEC)
@@ -3142,13 +3017,12 @@
 !SJ!    !!!!!!!!!!!!!!!!! SOLAR-J specific subroutines
 
 !---------------------------------------------------------------------
-      subroutine  FJX_CLIRAD_H2O(nlayers, PPP, TTT, HHH, TAUG_CLIRAD,RC)
+      subroutine  FJX_CLIRAD_H2O(nlayers, PPP, TTT, HHH, TAUG_CLIRAD)
 !---------------------------------------------------------------------
 
       integer,  intent(in):: nlayers
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
       real*8 ,  intent(out):: TAUG_CLIRAD(nlayers, 0:30)
-      integer, intent(out) :: RC
 
       character(len=255)  :: thisloc
       integer G, K, INDKG, L
@@ -3198,7 +3072,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at FJX_CLIRAD_H2O in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       TAUG_CLIRAD = 0.d0
 
 ! 0:0 will assign to bin 18 which is 0 for CLIRAD
@@ -3235,13 +3108,12 @@
 
 !!!!!!!!!!!!!!!!!!! SOLAR-J specific subroutines
 !---------------------------------------------------------------------
-      subroutine  FJX_GGLLNL_H2O(nlayers, PPP, TTT, HHH, TAUG_LLNL,RC)
+      subroutine  FJX_GGLLNL_H2O(nlayers, PPP, TTT, HHH, TAUG_LLNL)
 !---------------------------------------------------------------------
 
       integer,  intent(in):: nlayers
       real*8 ,  intent(in) :: PPP(nlayers+1), TTT(nlayers), HHH(nlayers)
       real*8 ,  intent(out):: TAUG_LLNL(nlayers, 0:21)
-      integer, intent(out) :: RC
 
       character(len=255)  :: thisloc
       integer G, K, INDKG, L
@@ -3279,7 +3151,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at FJX_GGLLNL_H2O in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       TAUG_LLNL = 0.d0
 
       ! 0:0 will assign to bin 18 which is 0 for CLIRAD
@@ -3319,7 +3190,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine ACLIM_FJX (YLATD,MONTH,PPP, TTT,O3,CH4, L1U,RC)
+      subroutine ACLIM_FJX (YLATD,MONTH,PPP, TTT,O3,CH4, L1U)
 !-----------------------------------------------------------------------
 !  Load fast-JX climatology - T & O3 - for latitude & month & pressure grid
 !-----------------------------------------------------------------------
@@ -3328,7 +3199,6 @@
       integer, intent(in)  :: MONTH, L1U
       real*8,  intent(in),  dimension(L1U+1) :: PPP
       real*8,  intent(out), dimension(L1U)   :: TTT,O3,CH4
-      integer, intent(out) :: RC
 
       real*8, dimension(LREF)   :: OREF2,TREF2,HREF2,CREF2
       real*8, dimension(LREF+1) :: PSTD
@@ -3338,7 +3208,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_FJX in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       TTT = 0.d0
       O3  = 0.d0
       CH4 = 0.d0
@@ -3394,7 +3263,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine ACLIM_RH (PL, TL, QL, RH, L1U,RC)
+      subroutine ACLIM_RH (PL, TL, QL, RH, L1U)
 !-----------------------------------------------------------------------
 !  Calculates RH profile given PL(mid-pressure), TL(K), QL (spec hum)
 !  May nee RH @ L1U (top layer, not CTM) so aerosol calls are stable
@@ -3403,7 +3272,6 @@
       integer, intent(in):: L1U
       real*8,  intent(in),  dimension(L1U) :: PL,TL,QL
       real*8,  intent(out), dimension(L1U) :: RH
-      integer, intent(out) :: RC
 ! local variables
       character(len=255)  ::  thisloc
       real*8  T, eps, es, qs
@@ -3411,8 +3279,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_RH in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
-      RH = 0.d0
 
       eps=287.04d0/461.50d0
       do L = 1,L1U-1
@@ -3433,7 +3299,7 @@
 
 
 !-----------------------------------------------------------------------
-      subroutine ACLIM_GEO (YLATD,MONTH,PPP, AERS,NAER, L1U,RC)
+      subroutine ACLIM_GEO (YLATD,MONTH,PPP, AERS,NAER, L1U)
 !-----------------------------------------------------------------------
 !  Load GEOMIP SSA climatology (vs P) for latitude & month given pressure grid
 !-----------------------------------------------------------------------
@@ -3445,7 +3311,6 @@
       real*8,  intent(in),  dimension(L1U+1) :: PPP
       real*8,  intent(out), dimension(L1U)   :: AERS
       integer, intent(out), dimension(L1U)   :: NAER
-      integer, intent(out) :: RC
 
       character(len=255)  ::  thisloc
       real*8, dimension(LGREF+2) :: RREF2,XREF2,PREF2    ! param LGREF=19
@@ -3455,7 +3320,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ACLIM_GEO in module cldj_fjx_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       AERS = 0.d0
       NAER = 0
 

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -176,6 +176,7 @@
       if (CLDFLAG.lt.1 .or. CLDFLAG.gt.8)then
          call CLOUDJ_ERROR('Incorrect cloud index: must be between 1 and 8'// &
               ' except 4', thisloc, rc)
+         return
       endif
 
 !--------------------CLDFLAG =  1, 2, 3---------------------------------
@@ -222,10 +223,6 @@
          call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,       &
                   DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,       &
                   NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK, RC)
-         if ( rc /= CLDJ_SUCCESS ) then
-            call CLOUDJ_ERROR( 'Error calling PHOTO_JX', thisLoc, rc )
-            return
-         endif
          if (.not.LDARK) then
             JCOUNT = JCOUNT + 1
          endif
@@ -267,22 +264,12 @@
 !---CLT(cloud ice+liq OD) & IWPX & LWPX adjusted to quantized cld fr
 !-------------------------------------------------------------------------
          call ICA_NR(LPRTJ0,CLDX,CLT,IWPX,LWPX,ZZZ, CLDIW,LTOP,CBIN_,ICA_, &
-             CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,RC)
-         if ( rc /= CLDJ_SUCCESS ) then
-            call CLOUDJ_ERROR( 'Error generating max-ran cloud overlap groups', &
-                 thisLoc, rc )
-            return
-         endif
+             CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA)
 
 !---call ICA_ALL to generate the weight and cloud total OD of each ICA
 !-------------------------------------------------------------------------
          call ICA_ALL(LPRTJ0,CLDX,CLT,LTOP,CBIN_,ICA_, CFBIN,     &
-            CLDCOR,NCLDF,GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL,RC)
-         if ( rc /= CLDJ_SUCCESS ) then
-            call CLOUDJ_ERROR( 'Error generating weight and cloud total OD', &
-                 thisLoc, rc )
-            return
-         endif
+            CLDCOR,NCLDF,GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL)
 
          if(LPRTJ0) then
             write(6,*) ' cloud-J v7.7  internal print:  #ICAs = ',NICA
@@ -292,6 +279,7 @@
 ! 4 = average direct beam over all ICAs  DISCONTINUED
          if (CLDFLAG .eq. 4) then
             call CLOUDJ_ERROR('CLD FLAG = 4 not supported', thisloc, rc)
+            return
          endif
 
 !-----------------------------------------------------------------------
@@ -315,11 +303,7 @@
                enddo
 
                call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR, &
-                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
-               if ( rc /= CLDJ_SUCCESS ) then
-                  call CLOUDJ_ERROR( 'Error using cloud flag 5', thisLoc, rc )
-                  return
-               endif
+                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
 
 !---zero out cloud water paths which are not in the selected random ICA
                do L = 1, LTOP
@@ -345,10 +329,6 @@
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                      DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,        &
                      NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
-               if ( rc /= CLDJ_SUCCESS ) then
-                  call CLOUDJ_ERROR( 'Error using cloud flag 5', thisLoc, rc )
-                  return
-               endif
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
                endif
@@ -378,11 +358,7 @@
          if (CLDFLAG .eq. 6) then
 
             call ICA_QUD(WCOL,OCOL,ICA_,NQD_,NICA, &
-                         WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
-            if ( rc /= CLDJ_SUCCESS ) then
-               call CLOUDJ_ERROR( 'Error using cloud flag 6', thisLoc, rc )
-               return
-            endif
+                         WTQCA, ISORT,NQ1,NQ2,NDXQS)
 
             if (LPRTJ0) then
                write(6,'(a)') ' quadrature QCAs(mid-pt): wt/range/index/OD'
@@ -398,11 +374,7 @@
                   I = ISORT(NDXQS(N))
 
                   call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR,  &
-                                GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
-                  if ( rc /= CLDJ_SUCCESS ) then
-                     call CLOUDJ_ERROR( 'Error using cloud flag 6', thisLoc, rc )
-                     return
-                  endif
+                                GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
 
 !---zero out cloud water paths which are not in the selected QCA
                   do L = 1, LTOP
@@ -419,10 +391,6 @@
                   call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH, &
                    DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,     &
                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK, RC)
-                  if ( rc /= CLDJ_SUCCESS ) then
-                     call CLOUDJ_ERROR( 'Error using cloud flag 6', thisLoc, rc )
-                     return
-                  endif
                   if (.not.LDARK) then
                      JCOUNT = JCOUNT + 1
                   endif
@@ -453,11 +421,7 @@
          if (CLDFLAG .eq. 7) then
 
             call ICA_QUD(WCOL,OCOL,ICA_,NQD_,NICA, &
-                         WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
-         if ( rc /= CLDJ_SUCCESS ) then
-            call CLOUDJ_ERROR( 'Error using cloud flag 7', thisLoc, rc )
-            return
-         endif
+                         WTQCA, ISORT,NQ1,NQ2,NDXQS)
 
             if (LPRTJ0) then
                write(6,'(a)') ' quadrature QCAs(avg-cld): wt/range/index/OD'
@@ -475,11 +439,7 @@
                         I = ISORT(II)
 
                         call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR, &
-                                      GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
-                        if ( rc /= CLDJ_SUCCESS ) then
-                           call CLOUDJ_ERROR( 'Error using cloud flag 7', thisLoc, rc )
-                           return
-                        endif
+                                      GNR,    GBOT, GTOP, NRG,   NICA, TTCOL  )
 
                         if (LPRTJ0) then
                            write(6,'(a,3i5,2f8.4,f9.3)') &
@@ -514,10 +474,6 @@
                      call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                           DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
                           NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
-                     if ( rc /= CLDJ_SUCCESS ) then
-                        call CLOUDJ_ERROR( 'Error using cloud flag 7', thisLoc, rc )
-                        return
-                     endif
                
                      if (.not.LDARK) then
                         JCOUNT = JCOUNT + 1
@@ -557,11 +513,7 @@
             endif
             do I = 1, NICA
                call ICA_III( LPRTJ0, CLT,  LTOP, CBIN_, I,    NCLDF, GFNR,  &
-                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
-               if ( rc /= CLDJ_SUCCESS ) then
-                  call CLOUDJ_ERROR( 'Error using cloud flag 8', thisLoc, rc )
-                  return
-               endif
+                             GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
 !---zero out cloud water paths which are not in the selected random ICA
                do L = 1, LTOP
                   LWPX(L) = LWP(L)
@@ -576,11 +528,7 @@
 !-----------------------------------------------------------------------
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                     DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
-                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
-               if ( rc /= CLDJ_SUCCESS ) then
-                  call CLOUDJ_ERROR( 'Error using cloud flag 8', thisLoc, rc )
-                  return
-               endif
+                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK, RC)
                
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
@@ -614,7 +562,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_NR(LPRTJ0,CLDF,CLTAU,IWPX,LWPX,ZZZ,CLDIW,LTOP,CBIN_, &
-            ICA_,CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,RC)
+            ICA_,CFBIN,CLDCOR,NCLDF, GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA)
 !-----------------------------------------------------------------------
 !---revised in v7.7 (02/2020) fixed MAX-RAN (#0 & #3) set CLDCOR=0 if need be
 !---Read in the cloud fraction (CLDF), cloud OD (CLTAU), cloud index (CLDIW)
@@ -669,7 +617,6 @@
       integer, intent(out), dimension(9) :: GBOT,GTOP,GLVL,GNR,GCMX
       integer, intent(out), dimension(9,CBIN_+1) :: GFNR
       real*8,  intent(out), dimension(CBIN_) :: CFBIN
-      integer, intent(out) :: RC
 
       character(len=255)        :: thisloc
       real*8   FBIN, FSCALE, CLF_MIN, CLF_MAX, FSCALE2
@@ -682,7 +629,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_NR in module cldj_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       NRG   = 0
       NICA  = 0
       NCLDF = 0
@@ -1001,7 +947,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_ALL(LPRTJ0,CLF,CLT,LTOP,CBINU,ICAU, CFBIN,CLDCOR,NCLDF,  &
-           GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL,RC)
+           GFNR,GCMX,GNR,GBOT,GTOP,GLVL,NRG,NICA,  WCOL,OCOL)
 !-----------------------------------------------------------------------
 !    OCOL() = cloud optical depth (total) in each ICA
 !    WCOL() = weight(fract area) of ICA,
@@ -1027,7 +973,6 @@
       real*8,  intent(in), dimension(CBINU) :: CFBIN
       real*8,  intent(in)                   :: CLDCOR
       real*8,  intent(out),dimension(ICAU)  :: WCOL,OCOL
-      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       real*8  ODCOL,WTCOL,CF0(51),  FWT(10,51),FWTC(10,51),FWTCC(10,51)
@@ -1038,7 +983,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_ALL in module cldj_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       WCOL = 0.d0
       OCOL = 0.d0
 
@@ -1155,7 +1099,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_III(LPRTJ0, CLT,  LTOP, CBINU, III,  NCLDF, GFNR, &
-                         GNR,    GBOT, GTOP, NRG,   NICA, TTCOL, RC )
+                         GNR,    GBOT, GTOP, NRG,   NICA, TTCOL )
 !-----------------------------------------------------------------------
 !    see ICA_ALL, this subroutine picks out the ICA atmosphere #III
 !      and loads the REFF/WPs for a FAST_JX calculation.
@@ -1167,7 +1111,6 @@
       integer, intent(in), dimension(9,CBINU+1) :: GFNR
       real*8,  intent(in), dimension(LTOP)  :: CLT
       real*8,  intent(out),dimension(LTOP)  :: TTCOL
-      integer, intent(out) :: RC
 
       character(len=255) :: thisloc
       integer II, IG, G, L
@@ -1175,7 +1118,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_III in module cldj_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       TTCOL = 0.d0
 
       II = max(1, min(NICA,III))
@@ -1194,7 +1136,7 @@
 
 !-----------------------------------------------------------------------
       SUBROUTINE ICA_QUD(WCOL,OCOL, ICAU,NQDU,NICA, &
-                         WTQCA, ISORT,NQ1,NQ2,NDXQS,RC)
+                         WTQCA, ISORT,NQ1,NQ2,NDXQS)
 !-----------------------------------------------------------------------
 !---Take the full set of ICAs and group into the NQD_ ranges of total OD
 !---Create the Cumulative Prob Fn and select the mid-point ICA for each group
@@ -1207,7 +1149,6 @@
       real*8, intent(out), dimension(NQDU)      :: WTQCA
       integer, intent(out), dimension(ICAU)     :: ISORT
       integer, intent(out), dimension(NQDU)     :: NQ1,NQ2,NDXQS
-      integer, intent(out) :: RC
 
       character(len=255)       :: thisloc
       real*8,  dimension(ICA_) :: OCDFS, OCOLS
@@ -1218,7 +1159,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at ICA_QUD in module cldj_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       ISORT = 0
       NQ1   = 0
       NQ2   = 0
@@ -1237,11 +1177,7 @@
         ISORT(1) = 1
         OCOLS(1) = OCOL(1)
       else
-        call HEAPSORT_A (NICA,OCOL,OCOLS,ISORT,ICA_,RC)
-        if ( rc /= CLDJ_SUCCESS ) then
-           call CLOUDJ_ERROR( 'Error sorting ICAs', thisLoc, rc )
-           return
-        endif
+        call HEAPSORT_A (NICA,OCOL,OCOLS,ISORT,ICA_)
       endif
         OCDFS(1) = WCOL(ISORT(1))
       do I = 2,NICA
@@ -1282,7 +1218,7 @@
 
 
 !-----------------------------------------------------------------------
-      SUBROUTINE HEAPSORT_A (N,A,AX,IX,ND,RC)
+      SUBROUTINE HEAPSORT_A (N,A,AX,IX,ND)
 !-----------------------------------------------------------------------
 !  classic heapsort, sorts real*8 array A(N) into ASCENDING order,
 !     places sorted array AX(N):   AX(1) .le. AX(N)
@@ -1295,7 +1231,6 @@
       real*8, dimension(ND),intent(in)  :: A
       real*8, dimension(ND),intent(out) :: AX
       integer,dimension(ND),intent(out) :: IX
-      integer, intent(out) ::RC
 
       character(len=255) :: thisloc
       integer :: I,J,L,IR,IA
@@ -1304,7 +1239,6 @@
 
       ! initialize location and outputs for safety
       thisloc = ' -> at HEAPSORT_A in module cldj_sub_mod.F90'
-      rc = CLDJ_SUCCESS
       AX = 0.d0
       IX = 0
 

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -976,7 +976,7 @@
 
       character(len=255) :: thisloc
       real*8  ODCOL,WTCOL,CF0(51),  FWT(10,51),FWTC(10,51),FWTCC(10,51)
-      real*8  FIG1,FIG2,GCORR,GCOWT,CORRFAC, FCMX(10) ,CLTOT(100)
+      real*8  FIG1,FIG2,GCORR,GCOWT,CORRFAC, FCMX(10)
       integer I, II, IG1,IG2, G, L,  IGNR(10),GCLDY(10),GRP1,GRP2
       logical L_CLR1,L_CLR2  ,LSKIP   ,LGR_CLR(10)
 !-----------------------------------------------------------------------
@@ -986,9 +986,7 @@
       WCOL = 0.d0
       OCOL = 0.d0
 
-      CLTOT = 0.d0
-
-        CF0(1) = 0.d0
+      CF0(1) = 0.d0
       do L = 1,CBINU
         CF0(L+1) = CFBIN(L)
       enddo
@@ -1163,10 +1161,7 @@
       NQ1   = 0
       NQ2   = 0
       NDXQS = 0
-
-      ISORT = 0
       WTQCA = 0.d0
-      NDXQS = 0
       OCOLS = 0.d0
 
 !---sort all the Indep Column Atmos (ICAs) in order of increasing column OD

--- a/src/Interfaces/Standalone/CJ77.F90
+++ b/src/Interfaces/Standalone/CJ77.F90
@@ -116,7 +116,7 @@
         enddo
 !---sets climatologies for O3, T, D & Z
 !-----------------------------------------------------------------------
-      call ACLIM_FJX (YLAT,MONTH,PPP, TTT,O3,CH4, L1_, RC)
+      call ACLIM_FJX (YLAT,MONTH,PPP, TTT,O3,CH4, L1_)
       if ( RC /= CLDJ_SUCCESS ) then
          call CLOUDJ_ERROR_STOP( 'Failure in ACLIM_FJX', thisloc )
       endif
@@ -247,7 +247,7 @@
       if (LPRTJ) then
           write(6,'(a,f8.3,3f8.5)')'SZA SOLF U0 albedo' &
                 ,SZA,SOLF,U0,RFL(5,18)
-        call JP_ATM0(PPP,TTT,DDD,OOO,ZZZ, L_, RC)
+        call JP_ATM0(PPP,TTT,DDD,OOO,ZZZ, L_)
         if ( RC /= CLDJ_SUCCESS ) then
            call CLOUDJ_ERROR_STOP( 'Failure in JP_ATM0', thisloc )
         endif


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update addresses a slow-down in Cloud-J 7.7.2 due to the error handling updates in https://github.com/geoschem/Cloud-J/pull/19. That PR included adding status code checks in all Cloud-J subroutines and initializing subroutine output arrays to zero for safety. These two updates slowed down the model significantly. This PR returns Cloud-J to expected speed prior to that update by doing the following:
1. Only output status code from subroutines with an existing error check
2. Use intent inout for error codes rather than out to avoid resetting in every subroutine that uses it
3. Minimize status code checks to only what is needed to pass pre-existing error checks up the stack
4. Remove output initializations except where it is not obvious that all slots in the array are assigned within the subroutine

### Expected changes

This is a zero diff update but will increase speed. Note that the slow-down is not noticeable in Cloud-J standalone because that is for one column for a short period of time. It is noticeable in GEOS-Chem global runs for longer runs. For example, in my testing of a 1-day GEOS-Chem benchmark simulation at 4x5 I found the following timing for photolysis:

- GEOS-Chem 14.4.1: **14 s**
- Prior to https://github.com/geoschem/Cloud-J/pull/19: **14 s**
- 7.7.2 release: **259 s**
- 7.7.2 + status check reduction: **24 s**
- 7.7.2 + status check reduction + reduced initialization for safety: **14 s**

### Reference(s)

None

### Related Github Issues and PRs

https://github.com/geoschem/geos-chem/issues/2416
