### PR TITLE
Use JVN_ as max not exact number of J-values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the Cloud-J repository since the init
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.1] - TBD
+### Added
+- Added error handling to exit the model if JVN_ is less than number of entries in FJX_j2j.dat
+
+### Changed
+- Updated usage of variable JVN_ to be max # of J-values rather than exact # of J-values
+
 ## [8.0.0] - 2024-08-29
 ### Added
 - Added M. Prather's new Cloud-J v8 feature of UV absorption by water (source of differences between v7.7 and v8)

--- a/src/Core/cldj_cmn_mod.F90
+++ b/src/Core/cldj_cmn_mod.F90
@@ -111,13 +111,7 @@
 !------------------------------------------------------------------------------
 
       ! JVN_ :  max # of J-values
-#ifdef MODEL_GEOSCHEM
-      integer, parameter :: JVN_ = 166
-#elif MODEL_STANDALONE
-      integer, parameter :: JVN_ = 101
-#else
-#error "Invalid model selection: parameters only defined for MODEL_STANDALONE and MODEL_GEOSCHEM. Add parameters for additional models in cldj_cmn_mod.F90."
-#endif
+      integer, parameter :: JVN_ = 200
 
       ! AN_ :  max # of FJX aerosols in layer (needs NDX for each)
 #ifdef MODEL_GEOSCHEM

--- a/src/Core/cldj_init_mod.F90
+++ b/src/Core/cldj_init_mod.F90
@@ -1031,7 +1031,11 @@
          if (AMIROOT) write(6,'(a)') CLINE
       do J = 1,JVN_
        read (NUNIT,'(i4,1x,a50,4x,f5.3,2x,a6)') JJ,T_REACT,F_FJX,T_FJX
-       if (JJ .gt. JVN_) exit
+       if (JJ .eq. 9999 ) exit
+       if (JJ .gt. JVN_) then
+          call CLOUDJ_ERROR('JVN_ must be >= number of entries in FJX_j2j.dat!', thisloc, rc)
+          return
+       endif
         JLABEL(JJ) = T_REACT
         JFACTA(JJ) = F_FJX
         JVMAP(JJ) = T_FJX


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR updates how global variable `JVN_` is used. It is described in the code as maximum number of J-values but was used instead as the exact number of J-values by setting the maximum index of `FJX_j2j.dat` entries read. This set up the possibility of a silent bug if `FJX_j2j.dat` was expanded but `JVN_` remained the same.

This update introduces new behavior where `JVN_` is set to a high number beyond the number of entries in `FJX_j2j.dat`. File read of `FJX_j2j.dat` stops when `9999` is encountered at the start of a line. Previously `FJX_j2j.dat` files ended in `9999` so inclusion of that in the file is not new.

Besides preventing the silent bug described above this update is beneficial by enabling removal of model-dependent C-preprocessor blocks where `JVN_` values were set. Those values would need to be updated every time new photolysis reactions were added to external models. A drawback of this update, however, is that several arrays are allocated more memory than they need. However, the arrays are 1D and relatively small so this should not make a significant impact.

### Expected changes

This is a zero diff update.

### Reference(s)

None

### Related Github Issues and PRs

None
