### PR TITLE
Return arrays for computing UV flux diagnostics in external models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ## [8.0.2] - TBD
-### Added
 - Github actions workflow to build on windows
 - Tests which compare the output of Cloud-J to some saved reference output.
-- Added four new output arguments to CLOUD_JX and FAST_JX for use in computing UV flux diagnostics in external models 
+- Added four optional output arguments to CLOUD_JX to retrieve fluxes from FAST_JX: FSBOT, FJXBOT, FJFLX, FLXD
 
 ## [8.0.1] - 2024-09-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ## [8.0.2] - TBD
+### Added
 - Github actions workflow to build on windows
 - Tests which compare the output of Cloud-J to some saved reference output.
 - Added four optional output arguments to CLOUD_JX and made them required in PHOTO_JX to retrieve direct and diffuse fluxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [8.0.2] - TBD
 - Github actions workflow to build on windows
 - Tests which compare the output of Cloud-J to some saved reference output.
-- Added four optional output arguments to CLOUD_JX to retrieve fluxes from FAST_JX: FSBOT, FJXBOT, FJFLX, FLXD
+- Added four optional output arguments to CLOUD_JX and made them required in PHOTO_JX to retrieve direct and diffuse fluxes
 
 ## [8.0.1] - 2024-09-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Github actions workflow to build on windows
 - Tests which compare the output of Cloud-J to some saved reference output.
+- Added four new output arguments to CLOUD_JX and FAST_JX for use in computing UV flux diagnostics in external models 
 
 ## [8.0.1] - 2024-09-30
 ### Added

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -119,7 +119,8 @@ MODULE CLDJ_FJX_SUB_MOD
 !-----------------------------------------------------------------------
       subroutine PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ, PPP,ZZZ,TTT,HHH,    &
                        DDD,RRR,OOO, CCC, LWP,IWP,REFFL,REFFI,AERSP,    &
-                       NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK,RC)
+                       NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, &
+                       LDARK,FSBOT,FJBOT,FLXD,FJFLX,RC)
 !  PHOTO_JX is the gateway to single column fast-JX calculations:
 !    calc J's for a single column atmosphere (aka Indep Colm Atmos or ICA)
 !    needs P, T, O3, clds, aersls, SZA (not lat or long), albedos, ...
@@ -149,12 +150,16 @@ MODULE CLDJ_FJX_SUB_MOD
       integer, intent(in)                    :: L1U   ! cloud-j input
       integer, intent(in)                    :: NJXU  ! cloud-j input
 ! reports out the JX J-values, upper level program converts to CTM chemistry J's
-      real*8,intent(out), dimension(L1U-1,NJXU):: VALJXX ! cloud-j output
-      real*8,intent(out), dimension(S_+2,L1U)  :: SKPERD ! cloud-j output
-      real*8,  intent(out), dimension(6)       :: SWMSQ  ! cloud-j output
-      real*8,  intent(out), dimension(L1U)     :: OD18   ! cloud-j output
-      logical, intent(out)                     :: LDARK  ! cloud-j output
-      integer, intent(inout)                   :: RC     ! cloud-j output
+      real*8,  intent(out), dimension(L1U-1,NJXU) :: VALJXX
+      real*8,  intent(out), dimension(S_+2,L1U)   :: SKPERD
+      real*8,  intent(out), dimension(6)          :: SWMSQ
+      real*8,  intent(out), dimension(L1U)        :: OD18
+      logical, intent(out)                        :: LDARK
+      real*8,  intent(out), dimension(W_+W_r)     :: FSBOT
+      real*8,  intent(out), dimension(W_+W_r)     :: FJBOT
+      real*8,  intent(out), dimension(L1U,W_+W_r) :: FLXD
+      real*8,  intent(out), dimension(L1U,W_+W_r) :: FJFLX
+      integer, intent(inout)                      :: RC
 
 !-----------------------------------------------------------------------
       character(len=255)  ::  thisloc, errmsg
@@ -164,10 +169,10 @@ MODULE CLDJ_FJX_SUB_MOD
       real*8, dimension(L1_)   :: TTJ,HHJ,DDJ,RRJ,OOJ,CCJ
       integer,dimension(L1_)   :: JXTRA
 !
-      real*8, dimension(W_+W_r)       :: FJTOP,FJBOT,FSBOT,FLXD0
+      real*8, dimension(W_+W_r)       :: FJTOP, FLXD0
       real*8, dimension(5,W_+W_r)     :: FIBOT
-      real*8, dimension(L1_,W_+W_r)   :: AVGF, FJFLX
-      real*8, dimension(L1_,W_+W_r)   :: DTAUX, FLXD
+      real*8, dimension(L1_,W_+W_r)   :: AVGF
+      real*8, dimension(L1_,W_+W_r)   :: DTAUX
       real*8, dimension(8,L1_,W_+W_r) :: POMEGAX
 !
       real*8, dimension(L1_)        ::  DTAU600

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -30,7 +30,7 @@
       SUBROUTINE CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,  &
              RRR,OOO,CCC, LWP,IWP,REFFL,REFFI, CLDF,CLDCOR,CLDIW,      &
              AERSP,NDXAER,L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18,      &
-             IRAN,NICA, JCOUNT,LDARK,WTQCA,FSBOT, FJXBOT, FLXD, FJFLX,RC)
+             IRAN,NICA, JCOUNT,LDARK,WTQCA,RC,FSBOT,FJXBOT,FLXD,FJFLX )
 
 !---Current recommendation for best average J's is
 !     1) cloud decorellation w/ max-overlap blocks:  LNRG = 6 and CLDCOR = 0.33
@@ -128,11 +128,12 @@
       integer, intent(out)                        :: NICA
       integer, intent(out)                        :: JCOUNT
       logical, intent(out)                        :: LDARK
-      real*8,  intent(out), dimension(W_+W_r)     :: FSBOT
-      real*8,  intent(out), dimension(W_+W_r)     :: FJXBOT
-      real*8,  intent(out), dimension(L1U,W_+W_r) :: FLXD
-      real*8,  intent(out), dimension(L1U,W_+W_r) :: FJFLX
       integer, intent(out)                        :: RC
+      real*8,  intent(out), dimension(W_+W_r),     optional :: FSBOT
+      real*8,  intent(out), dimension(W_+W_r),     optional :: FJXBOT
+      real*8,  intent(out), dimension(L1U,W_+W_r), optional :: FLXD
+      real*8,  intent(out), dimension(L1U,W_+W_r), optional :: FJFLX
+
 !-----------------------------------------------------------------------
       character(len=255)          :: thisloc
       logical  LPRTJ0

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -180,6 +180,10 @@
       SWMSQQ  = 0.d0
       OD18    = 0.d0
       OD18Q   = 0.d0
+      FSBOT   = 0.d0
+      FJXBOT  = 0.d0
+      FLXD    = 0.d0
+      FJFLX   = 0.d0
 
 !---CLOUD_JX:   different cloud schemes
 !-----------------------------------------------------------------------

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -30,7 +30,7 @@
       SUBROUTINE CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,  &
              RRR,OOO,CCC, LWP,IWP,REFFL,REFFI, CLDF,CLDCOR,CLDIW,      &
              AERSP,NDXAER,L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18,      &
-             IRAN,NICA, JCOUNT,LDARK,WTQCA,RC)
+             IRAN,NICA, JCOUNT,LDARK,WTQCA,FSBOT, FJXBOT, FLXD, FJFLX,RC)
 
 !---Current recommendation for best average J's is
 !     1) cloud decorellation w/ max-overlap blocks:  LNRG = 6 and CLDCOR = 0.33
@@ -120,15 +120,19 @@
       real*8,  intent(in), dimension(L1U  )  :: CLDF
       integer, intent(in), dimension(L1U  )  :: CLDIW
 ! reports out the JX J-values, upper level program converts to CTM chemistry J's
-      real*8,intent(out), dimension(L1U-1,NJXU):: VALJXX
-      real*8,  intent(out), dimension(S_+2,L1U):: SKPERD
-      real*8,  intent(out), dimension(6)       :: SWMSQ
-      real*8,  intent(out), dimension(L1U)     :: OD18
-      real*8,  intent(out), dimension(NQD_)    :: WTQCA
-      integer, intent(out)                     :: NICA
-      integer, intent(out)                     :: JCOUNT
-      logical, intent(out)                     :: LDARK
-      integer, intent(out)                     :: RC
+      real*8,intent(out), dimension(L1U-1,NJXU)   :: VALJXX
+      real*8,  intent(out), dimension(S_+2,L1U)   :: SKPERD
+      real*8,  intent(out), dimension(6)          :: SWMSQ
+      real*8,  intent(out), dimension(L1U)        :: OD18
+      real*8,  intent(out), dimension(NQD_)       :: WTQCA
+      integer, intent(out)                        :: NICA
+      integer, intent(out)                        :: JCOUNT
+      logical, intent(out)                        :: LDARK
+      real*8,  intent(out), dimension(W_+W_r)     :: FSBOT
+      real*8,  intent(out), dimension(W_+W_r)     :: FJXBOT
+      real*8,  intent(out), dimension(L1U,W_+W_r) :: FLXD
+      real*8,  intent(out), dimension(L1U,W_+W_r) :: FJFLX
+      integer, intent(out)                        :: RC
 !-----------------------------------------------------------------------
       character(len=255)          :: thisloc
       logical  LPRTJ0
@@ -222,7 +226,8 @@
 !-----------------------------------------------------------------------
          call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,       &
                   DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,       &
-                  NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18, LDARK, RC)
+                  NDXAER, L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18,       &
+                  LDARK, FSBOT, FJXBOT, FLXD, FJFLX, RC)
          if (.not.LDARK) then
             JCOUNT = JCOUNT + 1
          endif
@@ -331,7 +336,8 @@
 !-----------------------------------------------------------------------
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                      DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,        &
-                     NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
+                     NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q,    &
+                     LDARK,FSBOT, FJXBOT, FLXD, FJFLX,RC)
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
                endif
@@ -393,7 +399,8 @@
 !-----------------------------------------------------------------------
                   call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH, &
                    DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,     &
-                   NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK, RC)
+                   NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, &
+                   LDARK, FSBOT, FJXBOT, FLXD, FJFLX, RC)
                   if (.not.LDARK) then
                      JCOUNT = JCOUNT + 1
                   endif
@@ -474,9 +481,11 @@
                      endif
 
 !-----------------------------------------------------------------------
+
                      call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                           DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
-                          NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK,RC)
+                          NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q,     &
+                          LDARK, FSBOT, FJXBOT, FLXD, FJFLX,RC)
                
                      if (.not.LDARK) then
                         JCOUNT = JCOUNT + 1
@@ -531,8 +540,8 @@
 !-----------------------------------------------------------------------
                call PHOTO_JX (U0,SZA,RFL,SOLF, LPRTJ0, PPP,ZZZ,TTT,HHH,     &
                     DDD,RRR,OOO,CCC, LWPX,IWPX,REFFLX,REFFIX,AERSP,         &
-                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q, LDARK, RC)
-               
+                    NDXAER, L1U,ANU,NJXU, VALJXXX,SKPERDD,SWMSQQ,OD18Q,     &
+                    LDARK, FSBOT, FJXBOT, FLXD, FJFLX, RC)
                if (.not.LDARK) then
                   JCOUNT = JCOUNT + 1
                endif

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -155,7 +155,7 @@
       real*8,  dimension(S_+2,L1U)   :: SKPERDD
       real*8,  dimension(6)          :: SWMSQQ
       real*8,  dimension(L1U)        :: OD18Q
-      real*8,  dimension(W_+W_r),    :: FSBOT
+      real*8,  dimension(W_+W_r)     :: FSBOT
       real*8,  dimension(W_+W_r)     :: FJXBOT
       real*8,  dimension(L1U,W_+W_r) :: FLXD
       real*8,  dimension(L1U,W_+W_r) :: FJFLX

--- a/src/Core/cldj_sub_mod.F90
+++ b/src/Core/cldj_sub_mod.F90
@@ -30,7 +30,8 @@
       SUBROUTINE CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,  &
              RRR,OOO,CCC, LWP,IWP,REFFL,REFFI, CLDF,CLDCOR,CLDIW,      &
              AERSP,NDXAER,L1U,ANU,NJXU, VALJXX,SKPERD,SWMSQ,OD18,      &
-             IRAN,NICA, JCOUNT,LDARK,WTQCA,RC,FSBOT,FJXBOT,FLXD,FJFLX )
+             IRAN,NICA, JCOUNT,LDARK,WTQCA,RC,                         &
+             DirSfcFlux, DiffSfcFlux, DepFlux, DiffTopFlux            )
 
 !---Current recommendation for best average J's is
 !     1) cloud decorellation w/ max-overlap blocks:  LNRG = 6 and CLDCOR = 0.33
@@ -129,31 +130,35 @@
       integer, intent(out)                        :: JCOUNT
       logical, intent(out)                        :: LDARK
       integer, intent(out)                        :: RC
-      real*8,  intent(out), dimension(W_+W_r),     optional :: FSBOT
-      real*8,  intent(out), dimension(W_+W_r),     optional :: FJXBOT
-      real*8,  intent(out), dimension(L1U,W_+W_r), optional :: FLXD
-      real*8,  intent(out), dimension(L1U,W_+W_r), optional :: FJFLX
+      real*8,  intent(out), dimension(W_+W_r),     optional :: DirSfcFlux
+      real*8,  intent(out), dimension(W_+W_r),     optional :: DiffSfcFlux
+      real*8,  intent(out), dimension(L1U,W_+W_r), optional :: DepFlux
+      real*8,  intent(out), dimension(L1U,W_+W_r), optional :: DiffTopFlux
 
 !-----------------------------------------------------------------------
       character(len=255)          :: thisloc
       logical  LPRTJ0
       integer  I,II,J,K,L,M,N, LTOP, NRG,IRANX, NRANDO
       real*8   CLDFR, XRAN, FSCALE, QCAOD, WTRAN
-      real*8,  dimension(L1U)     :: LWPX,IWPX,REFFLX,REFFIX
-      real*8,  dimension(LWEPAR)  :: CLTL,CLTI, CLT,CLDX
-      integer, dimension(LWEPAR)  :: NCLDF
+      real*8,  dimension(L1U)        :: LWPX, IWPX, REFFLX, REFFIX
+      real*8,  dimension(LWEPAR)     :: CLTL, CLTI,  CLT, CLDX
+      integer, dimension(LWEPAR)     :: NCLDF
       ! # max-verlap groups set at 9
-      integer, dimension(9)       :: GBOT,GTOP,GLVL,GNR,GCMX
-      integer, dimension(9,CBIN_+1) :: GFNR
-      real*8,  dimension(CBIN_)   ::  CFBIN
-      real*8,  dimension(ICA_)    ::    WCOL,OCOL, OCDFS
-      integer, dimension(ICA_)    :: ISORT
-      real*8,  dimension(LWEPAR+1)   :: TCLD,TTCOL,SOLT,TAUG
-      integer, dimension(NQD_)       :: NQ1,NQ2,NDXQS
-      real*8,  dimension(L1U-1,NJXU) ::  VALJXXX
-      real*8,  dimension(S_+2,L1U)  :: SKPERDD
-      real*8,  dimension(6)         :: SWMSQQ
-      real*8,  dimension(L1U)       :: OD18Q
+      integer, dimension(9)          :: GBOT, GTOP, GLVL, GNR, GCMX
+      integer, dimension(9,CBIN_+1)  :: GFNR
+      real*8,  dimension(CBIN_)      :: CFBIN
+      real*8,  dimension(ICA_)       :: WCOL, OCOL,OCDFS
+      integer, dimension(ICA_)       :: ISORT
+      real*8,  dimension(LWEPAR+1)   :: TCLD, TTCOL, SOLT, TAUG
+      integer, dimension(NQD_)       :: NQ1, NQ2, NDXQS
+      real*8,  dimension(L1U-1,NJXU) :: VALJXXX
+      real*8,  dimension(S_+2,L1U)   :: SKPERDD
+      real*8,  dimension(6)          :: SWMSQQ
+      real*8,  dimension(L1U)        :: OD18Q
+      real*8,  dimension(W_+W_r),    :: FSBOT
+      real*8,  dimension(W_+W_r)     :: FJXBOT
+      real*8,  dimension(L1U,W_+W_r) :: FLXD
+      real*8,  dimension(L1U,W_+W_r) :: FJFLX
 
 !-----------------------------------------------------------------------
 
@@ -569,6 +574,12 @@
 !-----------------------------------------------------------------------
 
       endif
+
+      ! Set optional outputs
+      IF ( PRESENT( DirSfcFlux  ) ) DirSfcFlux  = FSBOT
+      IF ( PRESENT( DiffSfcFlux ) ) DiffSfcFlux = FJXBOT
+      IF ( PRESENT( DepFlux     ) ) DepFlux     = FLXD
+      IF ( PRESENT( DiffTopFlux ) ) DiffTopFlux = FJFLX
 
       END SUBROUTINE CLOUD_JX
 

--- a/src/Interfaces/Standalone/cldj_standalone.F90
+++ b/src/Interfaces/Standalone/cldj_standalone.F90
@@ -392,7 +392,8 @@
        call CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,       &
                RRR,OOO,CCC, LWP,IWP,REFFL,REFFI, CLF,CLDCOR,CLDIW,    &
                AERSP,NDXAER,L1U,ANU,JVNU, VALJXX,SKPERD,SWMSQ,OD18,    &
-               IRAN,NICA, JCOUNT,LDARK,WTQCA,FSBOT,FJXBOT,FLXD,FJFLX,RC)
+               IRAN,NICA, JCOUNT,LDARK,WTQCA,RC,FSBOT=FSBOT,           &
+               FJXBOT=FJXBOT,FLXD=FLXD,FJFLX=FJFLX)
        if ( RC /= CLDJ_SUCCESS ) then
           call CLOUDJ_ERROR_STOP( 'Failure in CLOUD_JX', thisloc )
        endif

--- a/src/Interfaces/Standalone/cldj_standalone.F90
+++ b/src/Interfaces/Standalone/cldj_standalone.F90
@@ -31,6 +31,10 @@
       real*8,  dimension(L_,JVN_) :: VALJXX
       real*8,  dimension(5,S_)    :: RFL
       real*8,  dimension(NQD_)    :: WTQCA
+      real*8,  dimension(W_+W_r)     :: FSBOT
+      real*8,  dimension(W_+W_r)     :: FJXBOT
+      real*8,  dimension(L1_,W_+W_r) :: FLXD
+      real*8,  dimension(L1_,W_+W_r) :: FJFLX
 
 !-------------local use-----------------------
       integer :: NSZA,MONTH,ILAT
@@ -379,12 +383,16 @@
       SWMSQ(:)= 0.d0
       OD18(:) =0.d0
       WTQCA(:)= 0.d0
+      FSBOT(:)= 0.d0
+      FJXBOT(:)= 0.d0
+      FLXD(:,:)= 0.d0
+      FJFLX(:,:)= 0.d0
 
 !=======================================================================
        call CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,       &
                RRR,OOO,CCC, LWP,IWP,REFFL,REFFI, CLF,CLDCOR,CLDIW,    &
                AERSP,NDXAER,L1U,ANU,JVNU, VALJXX,SKPERD,SWMSQ,OD18,    &
-               IRAN,NICA, JCOUNT,LDARK,WTQCA,RC)
+               IRAN,NICA, JCOUNT,LDARK,WTQCA,FSBOT,FJXBOT,FLXD,FJFLX,RC)
        if ( RC /= CLDJ_SUCCESS ) then
           call CLOUDJ_ERROR_STOP( 'Failure in CLOUD_JX', thisloc )
        endif

--- a/src/Interfaces/Standalone/cldj_standalone.F90
+++ b/src/Interfaces/Standalone/cldj_standalone.F90
@@ -31,10 +31,6 @@
       real*8,  dimension(L_,JVN_) :: VALJXX
       real*8,  dimension(5,S_)    :: RFL
       real*8,  dimension(NQD_)    :: WTQCA
-      real*8,  dimension(W_+W_r)     :: FSBOT
-      real*8,  dimension(W_+W_r)     :: FJXBOT
-      real*8,  dimension(L1_,W_+W_r) :: FLXD
-      real*8,  dimension(L1_,W_+W_r) :: FJFLX
 
 !-------------local use-----------------------
       integer :: NSZA,MONTH,ILAT
@@ -383,17 +379,12 @@
       SWMSQ(:)= 0.d0
       OD18(:) =0.d0
       WTQCA(:)= 0.d0
-      FSBOT(:)= 0.d0
-      FJXBOT(:)= 0.d0
-      FLXD(:,:)= 0.d0
-      FJFLX(:,:)= 0.d0
 
 !=======================================================================
        call CLOUD_JX (U0,SZA,RFL,SOLF,LPRTJ,PPP,ZZZ,TTT,HHH,DDD,       &
                RRR,OOO,CCC, LWP,IWP,REFFL,REFFI, CLF,CLDCOR,CLDIW,    &
                AERSP,NDXAER,L1U,ANU,JVNU, VALJXX,SKPERD,SWMSQ,OD18,    &
-               IRAN,NICA, JCOUNT,LDARK,WTQCA,RC,FSBOT=FSBOT,           &
-               FJXBOT=FJXBOT,FLXD=FLXD,FJFLX=FJFLX)
+               IRAN,NICA, JCOUNT,LDARK,WTQCA,RC)
        if ( RC /= CLDJ_SUCCESS ) then
           call CLOUDJ_ERROR_STOP( 'Failure in CLOUD_JX', thisloc )
        endif


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR adds four output array arguments to subroutine `CLOUD_JX` and `PHOTO_JX`.  The arguments in CLOUD_JX are optional, while the arguments in PHOTO_JX are required. The arrays are needed to compute UV flux diagnostics in GEOS-Chem. The arrays are as follows, with the definitions from `cldj_fjx_sub_mod.F90`:

```
!     FJXBOT(1:W_) = diffuse flux onto surface (<0 by definition) (NOTE: called FJBOT in PHOTO_JX, FJX_BOT in CLOUD_JX)
!     FSBOT(1:W_) = direct/solar flux onto surface  (<0 by definition)
!     FJFLX(1:L_,1:W_) = diffuse flux across top of model layer L
!        this connects with FJBOT = FJFLX(0) & FJTOP = FJFLX(L_+1) (not dim!!)
!     FLXD(1:L_+1,1:W_) = solar flux deposited in layer L (includes lyr above
```

### Expected changes

This is a zero diff update, but will require additional arguments passed to Cloud-J when using from an external model.

### Reference(s)

None

### Related Github Issues and PRs

closes https://github.com/geoschem/Cloud-J/issues/28
