### PR TITLE
Fixed issues in format statements that caused errors in Cloud-J verbose output

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gcc_version: [12, 13, 14]
+        gcc_version: [13, 14, 15]
         build_type: [Debug, Release]
     env:
       FC: gfortran-${{ matrix.gcc_version }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -23,7 +23,7 @@ jobs:
       FC: gfortran-${{ matrix.gcc_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: brew install netcdf netcdf-fortran

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the Cloud-J repository since the init
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Changed the format statement in several verbose prints to avoid print errors
+
 ## [8.0.2] - 2015-03-25
 ### Added
 - Added Github actions workflow to build on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Changed the format statement in several verbose prints to avoid print errors
 - Replaced the gcc 12 compiler wtih gcc 15 in the MacOS GitHub action
+- Updated GitHub Action `checkout@v4` (which is deprecated) to `checkout@v6`
 
 ## [8.0.2] - 2015-03-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Changed
 - Changed the format statement in several verbose prints to avoid print errors
+- Replaced the gcc 12 compiler wtih gcc 15 in the MacOS GitHub action
 
 ## [8.0.2] - 2015-03-25
 ### Added

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -779,11 +779,11 @@ MODULE CLDJ_FJX_SUB_MOD
             write(6,'(i4,35f7.2)') L,(SKPERD(I,L), I=NW2+1,NWS2+2),SKPERD(S_+1,L)+SKPERD(S_+2,L)
          enddo
          write(6,'(a)') ' Fast-J ----J-values----'
-         write(6,'(1x,a,72(a6,3x))') 'L=  ',(TITLEJX(K), K=1,NJX)
+         write(6,'(1x,a,200(a6,3x))') 'L=  ',(TITLEJX(K), K=1,NJX)
          do L = LU,1,-1
-            write(6,'(i3,1p, 72e9.2)') L,(VALJXX(L,K),K=1,NJX)
+            write(6,'(i3,1p, 200e9.2)') L,(VALJXX(L,K),K=1,NJX)
          enddo
-            
+
       endif   ! end of LPRTJ if
 
       ! Error catch


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to https://github.com/geoschem/geos-chem/issues/3252.   We have done the following:

1. Updated the following format statements used to print these variables:

| Variable | Old format | New format | Why changed?
| ---- | ---- | ---- | ---- |
|  TITLEJX | `'(1x,a,72(a6,3x))'` |  `'(1x,a,200(a6,3x))'` | To prevent wrapping to a new line after the 72nd entry of TITLEJX is printed |
| VALJXX | `'(i3,1p, 72e9.2)'` | `'(i3,1p, 200e9.2)'` |  The 73rd element of VALJXX was being printed with an integer format `i3`, which caused simulations to halt with an error |

2. Removed the gcc12 compiler from the MacOS GitHub action and replaced it with gcc15.  This avoids an error, since gcc12 is no longer available on GitHub Actions runners that use MacOS.

### Expected changes
This will now allow runs using verbose output to proceed without halting due to a format error.

### Related Github Issues and PRs

- Closes https://github.com/geoschem/geos-chem/issues/3252