### PR TITLE
Modify aerosol indexing due to brown carbon addition into GEOS-Chem

### DIFF
--- a/src/Core/cldj_cmn_mod.F90
+++ b/src/Core/cldj_cmn_mod.F90
@@ -115,7 +115,7 @@
 
       ! AN_ :  max # of FJX aerosols in layer (needs NDX for each)
 #ifdef MODEL_GEOSCHEM
-      integer, parameter :: AN_=37
+      integer, parameter :: AN_=42
 #elif MODEL_STANDALONE
       integer, parameter :: AN_=25
 #endif
@@ -172,7 +172,7 @@
       ! A_   = dim = max no. of Aerosol Mie sets (input data) not including
       !        clouds and SSA
 #ifdef MODEL_GEOSCHEM
-      integer, parameter ::  A_=56
+      integer, parameter ::  A_=63 ! for BrC, MH 5/6/26
 #elif MODEL_STANDALONE
       integer, parameter ::  A_=40
 #endif

--- a/src/Core/cldj_fjx_sub_mod.F90
+++ b/src/Core/cldj_fjx_sub_mod.F90
@@ -779,9 +779,9 @@ MODULE CLDJ_FJX_SUB_MOD
             write(6,'(i4,35f7.2)') L,(SKPERD(I,L), I=NW2+1,NWS2+2),SKPERD(S_+1,L)+SKPERD(S_+2,L)
          enddo
          write(6,'(a)') ' Fast-J ----J-values----'
-         write(6,'(1x,a,72(a6,3x))') 'L=  ',(TITLEJX(K), K=1,NJX)
+         write(6,'(1x,a,*(a6,3x))') 'L=  ',(TITLEJX(K), K=1,NJX)
          do L = LU,1,-1
-            write(6,'(i3,1p, 72e9.2)') L,(VALJXX(L,K),K=1,NJX)
+            write(6,'(i3,1p, *(e9.2))') L,(VALJXX(L,K),K=1,NJX)
          enddo
             
       endif   ! end of LPRTJ if


### PR DESCRIPTION
### Name and Institution (Required)

Name: Megan He
Institution: Harvard University

### Describe the update

This PR implements brown carbon (BrC) in GEOS-Chem and Cloud-J following the optical property approach of Hammer et al. (2016), with the main purpose of investigating its effect on photolysis and global [OH]. The changes are related to aerosol indexing due to the additional aerosol species.

### Related Github Issues and PRs

See the GEOS-Chem PR in https://github.com/geoschem/geos-chem/pull/3301.
